### PR TITLE
Fix Haddock generation in `gh-pages`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,8 @@ jobs:
             && matrix.os == 'ubuntu-latest'
             && matrix.ghc == '9.10'
         run: >
+          mkdir -p gh-pages
+
           mv ${{ env.cabal-build-dir }}/build/*/*/*/doc/html/* gh-pages
 
           touch gh-pages/.nojekyll


### PR DESCRIPTION
This pull request fixes the generation of Haddock documentation in the `build.yml` Github workflow.