### PR TITLE
Define `successWithin`

### DIFF
--- a/lib/deltaq/src/DeltaQ.hs
+++ b/lib/deltaq/src/DeltaQ.hs
@@ -97,7 +97,7 @@ The distribution of delay times for a __sequence of hops__ is
 For example, the probability of five hops to succeed within 2 seconds
 is
 
-> > fromRational (successBefore (hops 5) 2) :: Double
+> > fromRational (successWithin (hops 5) 2) :: Double
 > 0.9547325102880658
 
 

--- a/lib/deltaq/src/DeltaQ/Class.hs
+++ b/lib/deltaq/src/DeltaQ/Class.hs
@@ -173,8 +173,11 @@ class   ( Eq (Probability o)
     -- | Probability of /not/ finishing.
     failure :: o -> Probability o
 
-    -- | Probability of finishing within the given time.
-    successBefore :: o -> Duration o -> Probability o
+    -- | Probability of finishing within the given time @t@.
+    --
+    -- \"Within\" is inclusive,
+    -- i.e. this returns the probability that the finishing time is @<= t@.
+    successWithin :: o -> Duration o -> Probability o
 
     -- | Given a probability @p@, return the smallest time @t@
     -- such that the probability of completing within that time
@@ -268,25 +271,22 @@ equality may be up to numerical accuracy.
 > failure (choice p x y) = p * failure x + (1-p) * failure y
 > failure (uniform r s)  = 0
 
-'successBefore'
+'successWithin'
 
-TODO: Boundary point - distinguish \"before\" from \"not after".
-Important for delta functions.
-
-> successBefore never    t = 0
-> successBefore (wait s) t = if t <= s then 0 else 1
+> successWithin never    t = 0
+> successWithin (wait s) t = if t < s then 0 else 1
 >
-> successBefore (x ./\. y) t =
->   successBefore t x * successBefore t y
-> successBefore (x .\/. y) t =
->   1 - (1 - successBefore t x) * (1 - successBefore t y)
+> successWithin (x ./\. y) t =
+>   successWithin t x * successWithin t y
+> successWithin (x .\/. y) t =
+>   1 - (1 - successWithin t x) * (1 - successWithin t y)
 >
-> successBefore (choice p x y) t =
->   p * successBefore t x + (1-p) * successBefore t y
-> successBefore (uniform r s) t
->   | t <= r          = 0
->   | r < t && t <= s = (t-r) / (s-r)
->   | s < t           = 1
+> successWithin (choice p x y) t =
+>   p * successWithin t x + (1-p) * successWithin t y
+> successWithin (uniform r s) t
+>   | t < r           = 0
+>   | r <= t && t < s = (t-r) / (s-r)
+>   | s <= t          = 1
 
 'quantile'
 

--- a/lib/deltaq/src/DeltaQ/PiecewisePolynomial.hs
+++ b/lib/deltaq/src/DeltaQ/PiecewisePolynomial.hs
@@ -69,9 +69,9 @@ instance DeltaQ (Durations Rational) where
         start = min a b
         end = max a b
 
-    successBefore o t
+    successWithin o t
         | Occurs t < earliest o = 0
-        | deadline o < Occurs t = 1
+        | deadline o <= Occurs t = 1
         | otherwise = PWP.cumulativeMass (unDurations o) t
 
     failure (Durations x) =

--- a/lib/deltaq/test/DeltaQ/PiecewisePolynomialSpec.hs
+++ b/lib/deltaq/test/DeltaQ/PiecewisePolynomialSpec.hs
@@ -170,38 +170,38 @@ spec = do
                 let s = r + d in
                 failure' (uniform r s)  ===  0
 
-    describe "successBefore" $ do
-        let successBefore' :: Durations Rational -> Rational -> Rational
-            successBefore' = successBefore
+    describe "successWithin" $ do
+        let successWithin' :: Durations Rational -> Rational -> Rational
+            successWithin' = successWithin
 
         xit "never" $ property $
             \(NonNegative t) ->
-                successBefore' never t  ===  0
+                successWithin' never t  ===  0
         it "wait" $ property $
             \(NonNegative t) (NonNegative s) ->
-                successBefore' (wait s) t  ===  if t < s then 0 else 1
+                successWithin' (wait s) t  ===  if t < s then 0 else 1
         xit "./\\." $ property $
             \(NonNegative t) x y ->
-                successBefore' (x ./\. y) t
-                    === successBefore' x t * successBefore' y t
+                successWithin' (x ./\. y) t
+                    === successWithin' x t * successWithin' y t
         xit ".\\/." $ property $
             \(NonNegative t) x y ->
-                successBefore' (x .\/. y) t
-                    === 1 - (1 - successBefore' x t) * (1 - successBefore' y t)
+                successWithin' (x .\/. y) t
+                    === 1 - (1 - successWithin' x t) * (1 - successWithin' y t)
         xit "choice" $ property $
             \(NonNegative t) (Probability p) x y ->
-                successBefore' (choice p x y) t
-                    ===  p * successBefore' x t + (1-p) * successBefore' y t
+                successWithin' (choice p x y) t
+                    ===  p * successWithin' x t + (1-p) * successWithin' y t
         it "uniform" $ property $ 
-            let successBefore2 r s t
-                    | t <= r          = 0
-                    | r < t && t <= s = (t-r) / (s-r)
-                    | s < t           = 1
+            let successWithin2 r s t
+                    | t < r           = 0
+                    | r <= t && t < s = (t-r) / (s-r)
+                    | s <= t          = 1
                     | otherwise       = error "impossible"
             in \(NonNegative t) (NonNegative r) (Positive d) ->
                 let s = r + d
-                in  successBefore' (uniform r s) t
-                        === successBefore2 r s t
+                in  successWithin' (uniform r s) t
+                        === successWithin2 r s t
 
     describe "quantile" $ do
         let quantile' :: Rational -> Durations Rational -> Eventually Rational


### PR DESCRIPTION
This pull request defines the function `successWithin` (`<= t`) and removes the functions `successBefore` (`< t`).

For exact numeric using `Rational`, this makes a difference, as `successWithin` can pick up a discrete event at time `== t`.