### PR TITLE
Implement `Numeric.Measure.Finite.Mixed`

### DIFF
--- a/lib/probability-polynomial/probability-polynomial.cabal
+++ b/lib/probability-polynomial/probability-polynomial.cabal
@@ -50,6 +50,7 @@ library
     Data.Function.Class
     Numeric.Function.Piecewise
     Numeric.Measure.Discrete
+    Numeric.Measure.Finite.Mixed
     Numeric.Polynomial.Simple
     PWPs.IRVs
 
@@ -86,6 +87,7 @@ test-suite test
   other-modules:
     Numeric.Function.PiecewiseSpec
     Numeric.Measure.DiscreteSpec
+    Numeric.Measure.Finite.MixedSpec
     Numeric.Polynomial.SimpleSpec
 
 benchmark probability-polynomial-benchmark

--- a/lib/probability-polynomial/src/Numeric/Measure/Finite/Mixed.hs
+++ b/lib/probability-polynomial/src/Numeric/Measure/Finite/Mixed.hs
@@ -1,0 +1,278 @@
+{-|
+Copyright   : (c) Predictable Network Solutions Ltd., 2024
+License     : BSD-3-Clause
+Maintainer  : peter.thompson@pnsol.com
+Description : Finite signed measures on the number line.
+-}
+module Numeric.Measure.Finite.Mixed
+    ( -- * Type
+      Measure
+    , zero
+    , dirac
+    , uniform
+    , total
+    , cumulative
+
+      -- * Numerical operations
+    , add
+    , scale
+    , translate
+    , convolve
+
+    -- * Internal, for testing
+    , unsafeFromCumulative
+    ) where
+
+import Data.Function.Class
+    ( Function (..)
+    )
+import Numeric.Function.Piecewise
+    ( Piecewise
+    )
+import Numeric.Polynomial.Simple
+    ( Poly
+    )
+
+import qualified Data.Map.Strict as Map
+import qualified Numeric.Function.Piecewise as Piecewise
+import qualified Numeric.Measure.Discrete as D
+import qualified Numeric.Polynomial.Simple as Poly
+
+{-----------------------------------------------------------------------------
+    Type
+------------------------------------------------------------------------------}
+-- | A finite
+-- [signed measure](https://en.wikipedia.org/wiki/Signed_measure)
+-- on the number line.
+newtype Measure a = Measure { getCumulative :: Piecewise a (Poly a) }
+    -- INVARIANT: Adjacent pieces contain distinct objects.
+    -- INVARIANT: The last piece is a constant polynomial,
+    --            so that the measure is finite.
+    deriving (Show)
+
+-- | Internal, for testing only.
+--
+-- Construct a signed measure from its cumulative function.
+unsafeFromCumulative :: (Ord a, Num a) => Piecewise a (Poly a) -> Measure a
+unsafeFromCumulative = Measure . trim
+
+-- | Internal.
+-- Join all intervals whose polynomials are equal.
+trim :: (Ord a, Num a) => Piecewise a (Poly a) -> Piecewise a (Poly a)
+trim = Piecewise.trim
+
+-- | Two measures are equal if they yield the same measures on every set.
+--
+-- @mx == my@ implies @forall t. cumulative mx t == cumulative my t@.
+instance (Ord a, Num a) => Eq (Measure a) where
+    Measure mx == Measure my =
+        Piecewise.toAscPieces mx == Piecewise.toAscPieces my
+
+{-----------------------------------------------------------------------------
+    Operations
+------------------------------------------------------------------------------}
+-- | The measure that assigns @0@ to every set.
+zero :: Num a => Measure a
+zero = Measure Piecewise.zero
+
+-- | A
+-- [Dirac measure](https://en.wikipedia.org/wiki/Dirac_measure)
+-- at the given point @x@.
+--
+-- > total (dirac x m) = m 
+dirac :: (Ord a, Num a) => a -> a -> Measure a
+dirac _ 0 = zero
+dirac x w = Measure $ Piecewise.fromAscPieces [(x, Poly.constant w)]
+
+-- | The probability measure of a uniform probability distribution
+-- in the interval $[x,y)$
+--
+-- > total (uniform x y) = 1
+uniform :: (Ord a, Num a, Fractional a) => a -> a -> Measure a
+uniform x y = Measure $ case compare x y of
+    EQ -> Piecewise.fromAscPieces [(x, 1)]
+    _  -> Piecewise.fromAscPieces [(low, poly), (high, 1)]
+  where
+    low = min x y
+    high = max x y
+    poly = Poly.lineFromTo (low, 0) (high, 1)
+
+-- | The total of the measure applied to the set of real numbers.
+total :: (Ord a, Num a) => Measure a -> a
+total (Measure p) =
+    case Piecewise.toAscPieces p of
+        [] -> 0
+        ps -> eval (snd (last ps)) 0
+
+-- | @cumulative x@ is the measure of the interval $(-∞, x]$.
+cumulative :: (Ord a, Num a) => Measure a -> a -> a
+cumulative (Measure p) x = eval p x
+
+-- | Add two measures.
+--
+-- > total (add mx my) = total mx + total my
+add :: (Ord a, Num a) => Measure a -> Measure a -> Measure a
+add (Measure mx) (Measure my) =
+    Measure $ trim $ Piecewise.zipPointwise (+) mx my
+
+-- | Scale a measure by a constant.
+--
+-- > total (scale a mx) = a * total mx
+scale :: (Ord a, Num a) => a -> Measure a -> Measure a
+scale 0 (Measure _) = zero
+scale x (Measure m) = Measure $ Piecewise.mapPieces (Poly.scale x) m
+
+-- | Translate a measure along the number line.
+--
+-- > cumulative (translate y m) x = cumulative m (x - y)
+translate :: (Ord a, Num a, Fractional a) => a -> Measure a -> Measure a
+translate y (Measure m) =
+    Measure $ Piecewise.translateWith Poly.translate y m
+
+{-----------------------------------------------------------------------------
+    Operations
+    Decomposition into continuous and discrete measures,
+    needed for convolution.
+------------------------------------------------------------------------------}
+-- | Measure that is absolutely continuous
+-- with respect to the Lebesgue measure,
+-- Represented via its cumulative function.
+newtype Continuous a = Continuous { unContinuous :: Piecewise a (Poly a) }
+    -- INVARIANT: The last piece is @Poly.constant p@ for some @p :: a@.
+
+-- | Density function (Radon–Nikodym derivative) of an absolutely
+-- continuous measure.
+newtype Density a = Density (Piecewise a (Poly a))
+    -- INVARIANT: The last piece is @Poly.constant 0@.
+
+-- | Density function of an absolutely continuous measure.
+toDensity
+    :: (Ord a, Num a, Fractional a)
+    => Continuous a -> Density a
+toDensity = Density . Piecewise.mapPieces Poly.differentiate . unContinuous
+
+-- | Decompose a mixed measure into
+-- a continuous measure and a discrete measure.
+-- See also [Lebesgue's decomposition theorem
+-- ](https://en.wikipedia.org/wiki/Lebesgue%27s_decomposition_theorem)
+decompose
+    :: (Ord a, Num a, Fractional a)
+    => Measure a -> (Continuous a, D.Discrete a)
+decompose (Measure m) =
+    ( Continuous $ trim $ Piecewise.fromAscPieces withoutJumps
+    , D.fromMap $ Map.fromList jumps
+    )
+  where
+    pieces = Piecewise.toAscPieces m
+
+    withoutJumps =
+        zipWith (\(x,o) j -> (x, o - Poly.constant j)) pieces totalJumps
+    totalJumps = tail $ scanl (+) 0 $ map snd jumps
+
+    jumps = go 0 pieces
+      where
+        go _ [] = []
+        go prev ((x,o) : xos) =
+            (x, Poly.eval o x - Poly.eval prev x) : go o xos
+
+{-----------------------------------------------------------------------------
+    Operations
+    Convolution
+------------------------------------------------------------------------------}
+{-$ NOTE [Convolution]
+
+In order to compute a convolution,
+we convolve a density with the cumulative function.
+
+Let $f$ denote a density, which can be continuous or a Dirac delta.
+Let $G$ denote a cumulative function.
+Let $H = f * G$ be the result of the convolution.
+It can be shown that this is the cumulative function of the
+convolution of the densities, $h = f * g$.
+
+The formula for convolution is
+
+$ H(y) = ∫ f(y - x) G(x) dx = ∫ f (x) G(y - x) dx$.
+
+When $f$ is a sum of delta functions, $f = Σ w_j delta_{x_j}(x)$,
+this integral becomes ($y - x = x_j$ => $x = y - x_j$)
+
+$ H(y) = Σ w_j G(y - x_j) $.
+
+When $f$ is a piecewise polynomial, we can convolve the pieces.
+
+When convolving with a cumulative function, the final piece
+will be a constant $g_n$ on the interval $[x_n,∞)$.
+In this case, the convolution is given by
+
+\[
+H(y)
+    = ∫ f (x) G(y - x) dx
+    = ∫_{ -∞}^{y-x_n} f(x) g_n dx
+    = g_n F(y-x_n)
+\]
+
+where $F$ is the cumulative function of the density $f$.
+-}
+
+-- | Convolve a discrete measure with a mixed measure.
+--
+-- See NOTE [Convolution].
+convolveDiscrete
+    :: (Ord a, Num a, Fractional a)
+    => D.Discrete a -> Measure a -> Measure a
+convolveDiscrete f gg =
+    foldr add zero
+        [ scale w (translate x gg)
+        | (x, w) <- Map.toAscList $ D.toMap f
+        ]
+
+-- | Convolve an absolutely continuous measure with a mixed measure.
+--
+-- See NOTE [Convolution].
+convolveContinuous
+    :: (Ord a, Num a, Fractional a)
+    => Continuous a -> Measure a -> Measure a
+convolveContinuous (Continuous ff) (Measure gg)
+    | null ffpieces = zero
+    | null ggpieces = zero
+    | otherwise = Measure $ trim $ boundedConvolutions + lastConvolution
+  where
+    ffpieces = Piecewise.toAscPieces ff
+    ggpieces = Piecewise.toAscPieces gg
+
+    Density f = toDensity (Continuous ff)
+    fpieces = Piecewise.toAscPieces f
+
+    -- Pieces on the bounded intervals
+    boundedPieces xos =
+        zipWith (\(x,o) (y,_) -> (x, y, o)) xos (drop 1 xos)
+
+    boundedConvolutions =
+        sum $
+            [ Piecewise.fromAscPieces (Poly.convolve fo ggo)
+            | fo <- boundedPieces fpieces
+            , ggo <- boundedPieces ggpieces
+            ]
+
+    (xlast, plast) = last ggpieces
+    glast = case Poly.toCoefficients plast of
+        [] -> 0
+        (a0:_) -> a0
+    lastConvolution =
+        Piecewise.mapPieces (Poly.scale glast)
+        $ Piecewise.translateWith Poly.translate xlast ff
+
+-- | Additive convolution of two measures.
+--
+-- > convolve (dirac x wx) (dirac y wy) = dirac (x + y) (wx * wy)
+-- > convolve (add mx my) mz = add (convolve mx mz) (convolve my mz)
+-- > convolve mx (add my mz) = add (convolve mx my) (convolve mx mz)
+-- > total (convolve mx my) = total mx * total my
+convolve
+    :: (Ord a, Num a, Fractional a)
+    => Measure a -> Measure a -> Measure a
+convolve mx my =
+    add (convolveContinuous contx my) (convolveDiscrete deltax my)
+  where
+    (contx, deltax) = decompose mx

--- a/lib/probability-polynomial/test/Numeric/Measure/Finite/MixedSpec.hs
+++ b/lib/probability-polynomial/test/Numeric/Measure/Finite/MixedSpec.hs
@@ -1,0 +1,137 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+{-|
+Copyright   : Predictable Network Solutions Ltd., 2024
+License     : BSD-3-Clause
+Maintainer  : peter.thompson@pnsol.com
+Description : Tests for finite signed measures.
+-}
+module Numeric.Measure.Finite.MixedSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Data.Function.Class
+    ( eval
+    )
+import Numeric.Measure.Finite.Mixed
+    ( Measure
+    , add
+    , convolve
+    , cumulative
+    , dirac
+    , uniform
+    , scale
+    , total
+    , translate
+    , unsafeFromCumulative
+    , zero
+    )
+import Numeric.Function.PiecewiseSpec
+    ( genPiecewise
+    )
+import Numeric.Polynomial.SimpleSpec
+    ( genPoly
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , pendingWith
+    , xit
+    )
+import Test.QuickCheck
+    ( Arbitrary
+    , Gen
+    , (===)
+    , (==>)
+    , arbitrary
+    , cover
+    , mapSize
+    , property
+    )
+
+import qualified Numeric.Function.Piecewise as Piecewise
+import qualified Numeric.Polynomial.Simple as Poly
+
+{-----------------------------------------------------------------------------
+    Tests
+------------------------------------------------------------------------------}
+spec :: Spec
+spec = do
+    describe "dirac" $ do
+        it "total" $ property $
+            \(x :: Rational) w ->
+                total (dirac x w)  ===  w
+
+    describe "uniform" $ do
+        it "total" $ property $
+            \(x :: Rational) y ->
+                total (uniform x y)  ===  1
+        
+        it "cumulative at midpoint" $ property $
+            \(x :: Rational) (y :: Rational) ->
+                x /= y ==>
+                cumulative (uniform x y) ((x+y)/2)  ===  1/2
+
+    describe "==" $ do
+        it "add m (scale (-1) m) == zero" $ property $
+            \(m :: Measure Rational) ->
+                cover 80 (total m /= 0) "nontrivial"
+                $ add m (scale (-1) m)  ===  zero
+
+    describe "add" $ do
+        it "total" $ property $
+            \(mx :: Measure Rational) my ->
+                total (add mx my)  ===  total mx + total my
+
+    describe "translate" $ do
+        it "…" $ do
+            pendingWith "Failures in Poly.translate"
+
+        xit "cumulative" $ property $
+            \(m :: Measure Rational) y x ->
+                cumulative (translate y m) x ===  cumulative m (x - y)
+
+    describe "convolve" $ do
+        it "dirac" $ property $
+            \(x :: Rational) wx y wy ->
+                convolve (dirac x wx) (dirac y wy)
+                    ===  dirac (x + y) (wx * wy)
+
+        it "total" $ property $ mapSize (`div` 10) $
+            \mx (my :: Measure Rational) ->
+                total (convolve mx my)
+                    === total mx * total my
+
+        it "distributes over `add`, left" $ property $ mapSize (`div` 12) $
+            \mx my (mz :: Measure Rational) ->
+                convolve (add mx my) mz
+                    === add (convolve mx mz) (convolve my mz) 
+
+        it "distributes over `add`, right" $ property $ mapSize (`div` 12) $
+            \mx my (mz :: Measure Rational) ->
+                convolve mx (add my mz)
+                    === add (convolve mx my) (convolve mx mz) 
+
+{-----------------------------------------------------------------------------
+    Random generators
+------------------------------------------------------------------------------}
+genMeasure :: Gen (Measure Rational)
+genMeasure =
+    unsafeFromCumulative . setLastPieceConstant <$> genPiecewise genPoly
+  where
+    setLastPieceConstant =
+        Piecewise.fromAscPieces
+        . setLastPieceConstant'
+        . Piecewise.toAscPieces
+
+    setLastPieceConstant' [] = []
+    setLastPieceConstant' [(x, o)] = [(x, Poly.constant (eval o x))]
+    setLastPieceConstant' (p : ps) = p : setLastPieceConstant' ps
+
+instance Arbitrary (Measure Rational) where
+    arbitrary = genMeasure


### PR DESCRIPTION
This pull request implements finite measures that have both continuous and discrete components. The measure is represented through its cumulative function as a piecewise polynomial.

We implement convolution by decomposing the first argument into a continuous part (polynomial pieces) and a discrete part (jumps between pieces) and specializing the integral to each part.