### PR TITLE
Add additional properties for `DeltaQ`

### DIFF
--- a/lib/deltaq/src/DeltaQ/Class.hs
+++ b/lib/deltaq/src/DeltaQ/Class.hs
@@ -249,11 +249,14 @@ equality may be up to numerical accuracy.
 
 'choice'
 
+> choice 1 x y = x
+> choice 0 x y = y
+>
 > choice p x y .>>. z  =  choice p (x .>>. z) (y .>>. z)
 > choice p x y ./\. z  =  choice p (x ./\. z) (y ./\. z)
 > choice p x y .\/. z  =  choice p (x .\/. z) (y .\/. z)
 
-'choices;
+'choices'
 
 > choices [] = never
 > choices ((w,o) : wos) = choice p o (choices wos)

--- a/lib/deltaq/test/DeltaQ/PiecewisePolynomialSpec.hs
+++ b/lib/deltaq/test/DeltaQ/PiecewisePolynomialSpec.hs
@@ -121,6 +121,14 @@ spec = do
                 x .\/. y  .===  y .\/. x
 
     describe "choice" $ do
+        it "choice 1" $ property $
+            \x y ->
+                choice 1 x y  .===  x
+
+        it "choice 0" $ property $
+            \x y ->
+                choice 0 x y  .===  y
+
         it ".>>." $ property $ mapSize (`div` 3) $
             \(Probability p) x y z ->
                 choice p x y .>>. z  .===  choice p (x .>>. z) (y .>>. z)


### PR DESCRIPTION
This pull request adds more properties to `DeltaQ`:

* Commutativity of `./\.` and `.\/.` for `Outcome`.
* Corner cases `p = 0` and `p = 1` for `choice`.