### PR TITLE
Add helper functions for `Eventually`

### DIFF
--- a/lib/deltaq/src/DeltaQ/Class.hs
+++ b/lib/deltaq/src/DeltaQ/Class.hs
@@ -21,6 +21,7 @@ module DeltaQ.Class
 
     -- ** DeltaQ
     , Eventually (..)
+    , eventually
     , eventuallyFromMaybe
     , maybeFromEventually
 
@@ -125,6 +126,13 @@ instance Applicative Eventually where
     Abandoned <*> (Occurs _) = Abandoned
     (Occurs _) <*> Abandoned = Abandoned
     (Occurs f) <*> (Occurs y) = Occurs (f y)
+
+-- | Helper function to eliminate 'Eventually'.
+--
+-- See also: 'maybe'.
+eventually :: b -> (a -> b) -> Eventually a -> b
+eventually b _ Abandoned = b
+eventually _ f (Occurs x) = f x
 
 -- | Helper function that converts 'Maybe' to 'Eventually'.
 eventuallyFromMaybe :: Maybe a -> Eventually a

--- a/lib/deltaq/test/DeltaQ/ClassSpec.hs
+++ b/lib/deltaq/test/DeltaQ/ClassSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 {-|
 Copyright   : Predictable Network Solutions Ltd., 2024
@@ -12,7 +13,9 @@ module DeltaQ.ClassSpec
 import Prelude
 
 import DeltaQ.Class
-    ( eventuallyFromMaybe
+    ( Eventually (..)
+    , eventually
+    , eventuallyFromMaybe
     , maybeFromEventually
     )
 import Test.Hspec
@@ -21,7 +24,8 @@ import Test.Hspec
     , it
     )
 import Test.QuickCheck
-    ( (===)
+    ( Arbitrary (..)
+    , (===)
     , property
     )
 
@@ -56,8 +60,18 @@ spec = do
                     in  (f <$> morphism mx <*> morphism my)
                         === morphism (f <$> mx <*> my)
 
-        describe "maybeFromEventually" $ do
-            it "maybeFromEventually . eventuallyFromMaybe" $ property $
-                \(mx :: Maybe Bool) ->
-                    maybeFromEventually (eventuallyFromMaybe mx)
-                        === mx
+        it "maybeFromEventually . eventuallyFromMaybe" $ property $
+            \(mx :: Maybe Bool) ->
+                maybeFromEventually (eventuallyFromMaybe mx)
+                    === mx
+
+        it "eventually Abandoned Occurs = id" $ property $
+            \(ex :: Eventually Bool) ->
+                eventually Abandoned Occurs ex 
+                    === ex
+
+{-----------------------------------------------------------------------------
+    Tests
+------------------------------------------------------------------------------}
+instance Arbitrary a => Arbitrary (Eventually a) where
+    arbitrary = eventuallyFromMaybe <$> arbitrary


### PR DESCRIPTION
This pull request adds the following small helper functions for the `Eventually` type:

```hs
maybeFromEventually :: Eventually a -> Maybe a
eventually :: b -> (a -> b) -> Eventually a → b
```
