### PR TITLE
Set package versions to `1.0.0.0`

### DIFF
--- a/lib/deltaq/deltaq.cabal
+++ b/lib/deltaq/deltaq.cabal
@@ -28,12 +28,10 @@ maintainer:      neil.davies@pnsol.ccom
 
 -- copyright:
 build-type:      Simple
-extra-doc-files:
+
+extra-source-files:
   CHANGELOG.md
   README.md
-
--- Extra source files to be distributed with the package, such as examples, or a tutorial module.
--- extra-source-files:
 
 common warnings
   ghc-options: -Wall

--- a/lib/probability-polynomial/probability-polynomial.cabal
+++ b/lib/probability-polynomial/probability-polynomial.cabal
@@ -17,12 +17,10 @@ maintainer:      peter.thompson@pnsol.com
 
 -- copyright:
 build-type:      Simple
-extra-doc-files:
+
+extra-source-files:
   CHANGELOG.md
   README.md
-
--- Extra source files to be distributed with the package, such as examples, or a tutorial module.
--- extra-source-files:
 
 common warnings
   ghc-options: -Wall
@@ -31,14 +29,6 @@ library
   import:           warnings
   hs-source-dirs:   src
   default-language: Haskell2010
-  other-extensions:
-    AllowAmbiguousTypes
-    FlexibleInstances
-    GeneralizedNewtypeDeriving
-    MonoLocalBinds
-    MultiParamTypeClasses
-    ScopedTypeVariables
-    TypeSynonymInstances
 
   build-depends:
     , base >= 4.14.3.0 && < 4.21
@@ -58,13 +48,6 @@ test-suite test
   type:             exitcode-stdio-1.0
   hs-source-dirs:   test
   default-language: Haskell2010
-  other-extensions:
-    AllowAmbiguousTypes
-    FlexibleInstances
-    GeneralizedNewtypeDeriving
-    MultiParamTypeClasses
-    ScopedTypeVariables
-    TypeSynonymInstances
 
   build-tool-depends: hspec-discover:hspec-discover
     


### PR DESCRIPTION
This pull request sets the package versions to `1.0.0.0` and constrains the versions of dependencies.

Part of #62