### PR TITLE
Define `quantile 0 x = Occurs 0`

### DIFF
--- a/lib/deltaq/src/DeltaQ/Class.hs
+++ b/lib/deltaq/src/DeltaQ/Class.hs
@@ -318,10 +318,11 @@ equality may be up to numerical accuracy.
 
 > p <= q  implies  quantile p o <= quantile q o
 >
-> quantile p never    = Abandoned
-> quantile p (wait t) = if p > 0 then Occurs t else Abandoned
+> quantile 0 x        = Occurs 0
+> quantile p never    = Abandoned       if p > 0
+> quantile p (wait t) = Occurs t        if p > 0
 >
-> quantile p (uniform r s)  =  r + p*(s-t)  if r <= s
+> quantile p (uniform r s)  =  r + p*(s-t)  if p > 0, r <= s
 
 'earliest'
 

--- a/lib/deltaq/src/DeltaQ/PiecewisePolynomial.hs
+++ b/lib/deltaq/src/DeltaQ/PiecewisePolynomial.hs
@@ -180,9 +180,10 @@ quantileFromMonotone pieces = findInSegments segments
   where
     segments = toSegments pieces
 
-    findInSegments [] y
-        | y == 0 = Just 0
-        | otherwise = Nothing
+    findInSegments _ 0
+        = Just 0
+    findInSegments [] _
+        = Nothing
     findInSegments (Jump x1 (y1, y2) : xys) y
         | y1 < y && y <= y2 = Just x1
         | otherwise = findInSegments xys y

--- a/lib/deltaq/test/DeltaQ/PiecewisePolynomialSpec.hs
+++ b/lib/deltaq/test/DeltaQ/PiecewisePolynomialSpec.hs
@@ -264,6 +264,10 @@ specProperties = do
         let quantile' :: Rational -> DQ -> Eventually Rational
             quantile' = quantile
 
+        it "0" $ property $
+            \o ->
+                quantile' 0 o  ===  Occurs 0
+
         it "monotonic" $ property $
             \o (Probability p) (Probability q) ->
                 let p' = min p q
@@ -273,16 +277,18 @@ specProperties = do
 
         it "never" $ property $
             \(Probability p) ->
-                quantile' p never  ===  Abandoned
+                p > 0 ==>
+                quantile' p never ===  Abandoned
 
         it "wait" $ property $
             \(Probability p) (NonNegative t) ->
-                quantile' p (wait t)
-                    ===  if p >= 0 then Occurs t else Abandoned
+                p > 0 ==>
+                quantile' p (wait t) ===  Occurs t
 
         it "uniform" $ property $
             \(Probability p) (NonNegative r) (Positive d) ->
                 let s = r + d in 
+                p > 0 ==>
                 quantile' p (uniform r s)
                     === Occurs (r + p*(s-r))
 


### PR DESCRIPTION
This pull request changes the definition of `quantile p` for the corner case `p = 0`. We set `quantile 0 x = Occurs 0`, as this value is the smallest value of type `Eventually Rational`.

Fixes #70 