### PR TITLE
Specialize `choose` to `Integer` instead of `Int`

### DIFF
--- a/lib/probability-polynomial/src/Numeric/Polynomial/Simple.hs
+++ b/lib/probability-polynomial/src/Numeric/Polynomial/Simple.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 
 {-|
@@ -360,16 +361,20 @@ convolve (lf, uf, Poly fs) (lg, ug, Poly gs)
 
 > eval (translate y p) x = eval p (x - y)
 -}
-translate :: (Fractional a, Eq a, Num a) => a -> Poly a -> Poly a
-translate s (Poly ps) = sum [b `scale` binomialExpansion n s | (n, b) <- zip [0 ..] ps]
+translate :: forall a. (Fractional a, Eq a, Num a) => a -> Poly a -> Poly a
+translate y (Poly ps) =
+    sum
+      [ b `scale` binomialExpansion n
+      | (n, b) <- zip [0 ..] ps
+      ]
   where
-    -- the binomial expansion of each power of x is a new polynomial
-    -- whose coefficients are the product of
-    -- a binomial coefficient and the shift value raised to a reducing power
-    binomialTerm :: Num a => a -> Int -> Int -> a
-    binomialTerm y n k = fromIntegral (n `choose` k) * (-y) ^ (n - k)
-    binomialExpansion :: Num a => Int -> a -> Poly a
-    binomialExpansion n y = Poly (map (binomialTerm y n) [0 .. n])
+    -- binomialTerm n k = coefficient of x^k in the expensation of (x - y)^n
+    binomialTerm :: Integer -> Integer -> a
+    binomialTerm n k = fromInteger (n `choose` k) * (-y) ^ (n - k)
+
+    -- binomialExpansion n = (x - y)^n  expanded as a polyonial in x
+    binomialExpansion :: Integer -> Poly a
+    binomialExpansion n = Poly (map (binomialTerm n) [0 .. n])
 
 {-|
 We use Sturm's Theorem to count the number of roots of a polynomial in a given interval.

--- a/lib/probability-polynomial/test/Numeric/Measure/Finite/MixedSpec.hs
+++ b/lib/probability-polynomial/test/Numeric/Measure/Finite/MixedSpec.hs
@@ -109,8 +109,7 @@ spec = do
                 total (add mx my)  ===  total mx + total my
 
     describe "translate" $ do
-        xit' "Failures in Poly.translate"
-            "distribution" $ property $
+        it "distribution" $ property $
             \(m :: Measure Rational) y x ->
                 eval (distribution (translate y m)) x
                     ===  eval (distribution m) (x - y)

--- a/lib/probability-polynomial/test/Numeric/Polynomial/SimpleSpec.hs
+++ b/lib/probability-polynomial/test/Numeric/Polynomial/SimpleSpec.hs
@@ -150,16 +150,12 @@ spec = do
                     ===  differentiate p * q + p * differentiate q
 
     describe "translate" $ do
-        let reason =
-                "Failures for degree > 70, probably Int overflow "
-                <> "when computing binomial coefficients."
-
-        xit' reason "eval" $ property $
+        it "eval" $ property $
             \p y (x :: Rational) ->
                 counterexample ("degree p = " <> show (degree p))
                 $ eval (translate y p) x  ===  eval p (x - y)
 
-        xit' reason "differentiate" $ property $
+        it "differentiate" $ property $
             \p (y :: Rational) ->
                 counterexample ("degree p = " <> show (degree p))
                 $ differentiate (translate y p)


### PR DESCRIPTION
This pull request changes the definition of `translate` to specialize `choose` to `Integer` instead of `Int`. This will avoid a silent `Int` overflow for polynomials of degree `> 70`.

Fixes #66 .