### PR TITLE
Remove first type argument of `Piecewise`

### DIFF
--- a/lib/deltaq/src/DeltaQ/PiecewisePolynomial.hs
+++ b/lib/deltaq/src/DeltaQ/PiecewisePolynomial.hs
@@ -57,7 +57,7 @@ newtype DQ = DQ (Measure Rational)
     deriving (Eq, Show, NFData)
 
 -- | Get the distribution function as piecewise function of polynomials.
-distribution :: DQ -> Piecewise Rational (Poly Rational)
+distribution :: DQ -> Piecewise (Poly Rational)
 distribution (DQ m) = Measure.distribution m
 
 -- | Interpret a finite, signed 'Measure' as a probability distribution.
@@ -84,7 +84,7 @@ unsafeFromPositiveMeasure = DQ
 onDistribution2
     :: (a ~ Rational)
     => String
-    -> (Piecewise a (Poly a) -> Piecewise a (Poly a) -> Piecewise a (Poly a))
+    -> (Piecewise (Poly a) -> Piecewise (Poly a) -> Piecewise (Poly a))
     -> DQ -> DQ -> DQ
 onDistribution2 err f (DQ mx) (DQ my) =
     DQ
@@ -156,7 +156,7 @@ data Segment a b
 
 -- | Helper function that elaborates a piecewise function
 -- into a list of segments.
-toSegments :: (a ~ Rational) => Piecewise a (Poly a) -> [Segment a a]
+toSegments :: (a ~ Rational) => Piecewise (Poly a) -> [Segment a a]
 toSegments = goJump 0 . Piecewise.toAscPieces
   where
     goJump _ [] = []
@@ -175,7 +175,7 @@ toSegments = goJump 0 . Piecewise.toAscPieces
         -- TODO: What about the case where y1 == y2, i.e. a constant Polynomial?
 
 -- | Compute a quantile from a monotonically increasing function.
-quantileFromMonotone :: (a ~ Rational) => Piecewise a (Poly a) -> a -> Maybe a
+quantileFromMonotone :: (a ~ Rational) => Piecewise (Poly a) -> a -> Maybe a
 quantileFromMonotone pieces = findInSegments segments
   where
     segments = toSegments pieces

--- a/lib/probability-polynomial/src/Numeric/Measure/Discrete.hs
+++ b/lib/probability-polynomial/src/Numeric/Measure/Discrete.hs
@@ -91,7 +91,7 @@ total (Discrete m) = sum m
 --
 -- This is known as the [distribution function
 -- ](https://en.wikipedia.org/wiki/Distribution_function_%28measure_theory%29).
-distribution :: (Ord a, Num a) => Discrete a -> Piecewise a (Poly a)
+distribution :: (Ord a, Num a) => Discrete a -> Piecewise (Poly a)
 distribution (Discrete m) =
     Piecewise.fromAscPieces
     $ zipWith (\(x,_) s -> (x,Poly.constant s)) diracs steps

--- a/lib/probability-polynomial/src/Numeric/Measure/Finite/Mixed.hs
+++ b/lib/probability-polynomial/src/Numeric/Measure/Finite/Mixed.hs
@@ -52,7 +52,7 @@ import qualified Numeric.Polynomial.Simple as Poly
 -- | A finite
 -- [signed measure](https://en.wikipedia.org/wiki/Signed_measure)
 -- on the number line.
-newtype Measure a = Measure (Piecewise a (Poly a))
+newtype Measure a = Measure (Piecewise (Poly a))
     -- INVARIANT: Adjacent pieces contain distinct objects.
     -- INVARIANT: The last piece is a constant polynomial,
     --            so that the measure is finite.
@@ -62,7 +62,7 @@ newtype Measure a = Measure (Piecewise a (Poly a))
 --
 -- This is known as the [distribution function
 -- ](https://en.wikipedia.org/wiki/Distribution_function_%28measure_theory%29).
-distribution :: (Ord a, Num a) => Measure a -> Piecewise a (Poly a)
+distribution :: (Ord a, Num a) => Measure a -> Piecewise (Poly a)
 distribution (Measure p) = p
 
 -- | Construct a signed measure from its
@@ -73,13 +73,13 @@ distribution (Measure p) = p
 -- that is if the last piece of the piecewise function is not constant.
 fromDistribution
     :: (Ord a, Num a)
-    => Piecewise a (Poly a) -> Maybe (Measure a)
+    => Piecewise (Poly a) -> Maybe (Measure a)
 fromDistribution pieces
     | isEventuallyConstant pieces = Just $ Measure $ trim pieces
     | otherwise = Nothing
 
 -- | Test whether a piecewise polynomial is consant as x -> ∞.
-isEventuallyConstant :: (Ord a, Num a) => Piecewise a (Poly a) -> Bool
+isEventuallyConstant :: (Ord a, Num a) => Piecewise (Poly a) -> Bool
 isEventuallyConstant pieces
     | null xpolys = True
     | otherwise = (<= 0) . Poly.degree . snd $ last xpolys
@@ -88,7 +88,7 @@ isEventuallyConstant pieces
 
 -- | Internal.
 -- Join all intervals whose polynomials are equal.
-trim :: (Ord a, Num a) => Piecewise a (Poly a) -> Piecewise a (Poly a)
+trim :: (Ord a, Num a) => Piecewise (Poly a) -> Piecewise (Poly a)
 trim = Piecewise.trim
 
 -- | Two measures are equal if they yield the same measures on every set.
@@ -199,12 +199,12 @@ translate y (Measure m) =
 -- | Measure that is absolutely continuous
 -- with respect to the Lebesgue measure,
 -- Represented via its distribution function.
-newtype Continuous a = Continuous { unContinuous :: Piecewise a (Poly a) }
+newtype Continuous a = Continuous { unContinuous :: Piecewise (Poly a) }
     -- INVARIANT: The last piece is @Poly.constant p@ for some @p :: a@.
 
 -- | Density function (Radon–Nikodym derivative) of an absolutely
 -- continuous measure.
-newtype Density a = Density (Piecewise a (Poly a))
+newtype Density a = Density (Piecewise (Poly a))
     -- INVARIANT: The last piece is @Poly.constant 0@.
 
 -- | Density function of an absolutely continuous measure.


### PR DESCRIPTION
This pull request simplifies the type `Piecewise a o` to `Piecewise o`. For all use case, we must have `a ~ Domain o` anyway, and this change improves the readability of the types.

On the other hand, this change makes us more dependent on the `TypeFamilies` and `FlexibleContexts` extensions, but we are using these extensions anyway, and this use is idiomatic.