### PR TITLE
Rename probability measures to `Numeric.Measure.Probability`

### DIFF
--- a/lib/probability-polynomial/probability-polynomial.cabal
+++ b/lib/probability-polynomial/probability-polynomial.cabal
@@ -41,8 +41,8 @@ library
     Numeric.Function.Piecewise
     Numeric.Measure.Discrete
     Numeric.Measure.Finite.Mixed
+    Numeric.Measure.Probability
     Numeric.Polynomial.Simple
-    Numeric.Probability.Mixed
     Numeric.Probability.Moments
 
 test-suite test
@@ -67,8 +67,8 @@ test-suite test
     Numeric.Function.PiecewiseSpec
     Numeric.Measure.DiscreteSpec
     Numeric.Measure.Finite.MixedSpec
+    Numeric.Measure.ProbabilitySpec
     Numeric.Polynomial.SimpleSpec
-    Numeric.Probability.MixedSpec
 
 benchmark probability-polynomial-benchmark
   import:           warnings

--- a/lib/probability-polynomial/src/Numeric/Measure/Probability.hs
+++ b/lib/probability-polynomial/src/Numeric/Measure/Probability.hs
@@ -6,7 +6,7 @@ License     : BSD-3-Clause
 Maintainer  : peter.thompson@pnsol.com
 Description : Probability measures on the number line.
 -}
-module Numeric.Probability.Mixed
+module Numeric.Measure.Probability
     ( -- * Type
       Prob
     , dirac

--- a/lib/probability-polynomial/test/Numeric/Measure/ProbabilitySpec.hs
+++ b/lib/probability-polynomial/test/Numeric/Measure/ProbabilitySpec.hs
@@ -7,7 +7,7 @@ Copyright   : Predictable Network Solutions Ltd., 2024
 License     : BSD-3-Clause
 Maintainer  : peter.thompson@pnsol.com
 -}
-module Numeric.Probability.MixedSpec
+module Numeric.Measure.ProbabilitySpec
     ( spec
     ) where
 
@@ -19,7 +19,7 @@ import Data.Function.Class
 import Data.Ratio
     ( (%)
     )
-import Numeric.Probability.Mixed
+import Numeric.Measure.Probability
     ( Prob
     , choice
     , convolve


### PR DESCRIPTION
This pull request renames the recently introduced module about probability measures to `Numeric.Measure.Probability` to make it more clear that this belongs to the `Numeric.Measure.*` family of concepts.