### PR TITLE
Add `SlackOrHazard`

### DIFF
--- a/lib/deltaq/deltaq.cabal
+++ b/lib/deltaq/deltaq.cabal
@@ -51,6 +51,7 @@ library
   exposed-modules:
     DeltaQ
     DeltaQ.Class
+    DeltaQ.Methods
     DeltaQ.PiecewisePolynomial
     DeltaQ.Plot
 
@@ -74,6 +75,7 @@ test-suite test
 
   other-modules:
     DeltaQ.ClassSpec
+    DeltaQ.MethodsSpec
     DeltaQ.PiecewisePolynomialSpec
 
 benchmark basic

--- a/lib/deltaq/src/DeltaQ.hs
+++ b/lib/deltaq/src/DeltaQ.hs
@@ -19,6 +19,8 @@ Specifically,
         This type represents a mixed discrete / continuous probability distribution
         where the continuous part is represented in terms of piecewise polynomials.
 
+    * common methods for analysis and construction in "DeltaQ.Methods"
+
     * plotting utilities in "DeltaQ.Plot"
 
         * 'plotCDFWithQuantiles' for plotting an instance of 'DeltaQ'
@@ -31,11 +33,13 @@ module DeltaQ
 
       -- * Modules
       module DeltaQ.Class
+    , module DeltaQ.Methods
     , module DeltaQ.Plot
     , module DeltaQ.PiecewisePolynomial
     ) where
 
 import DeltaQ.Class
+import DeltaQ.Methods
 import DeltaQ.PiecewisePolynomial
 import DeltaQ.Plot
 

--- a/lib/deltaq/src/DeltaQ/Class.hs
+++ b/lib/deltaq/src/DeltaQ/Class.hs
@@ -154,7 +154,7 @@ maybeFromEventually (Occurs x) = Just x
 --
 -- Specifically, 'DeltaQ' is the probability distribution
 -- of finish times for an outcome.
-class   ( Eq (Probability o)
+class   ( Ord (Probability o)
         , Enum (Probability o)
         , Num (Probability o)
         , Fractional (Probability o)

--- a/lib/deltaq/src/DeltaQ/Methods.hs
+++ b/lib/deltaq/src/DeltaQ/Methods.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-|
+Copyright   : Predictable Network Solutions Ltd., 2024
+License     : BSD-3-Clause
+Maintainer  : neil.davies@pnsol.com
+Description : Methods for analysis and construction.
+
+This module collects common methods
+for constructing 'DeltaQ' and analyzing them.
+-}
+module DeltaQ.Methods
+    ( -- * Slack / Hazard
+      meetsRequirement
+    , SlackOrHazard (..)
+    , isSlack
+    , isHazard
+    ) where
+
+import DeltaQ.Class
+    ( DeltaQ (..)
+    , Eventually (..)
+    , Outcome (..)
+    , eventually
+    )
+
+{-----------------------------------------------------------------------------
+    Methods
+    Slack / Hazard
+------------------------------------------------------------------------------}
+-- | The \"slack or hazard\" represents the distance between
+-- a reference point in (time, probability) space
+-- and a given 'DeltaQ'.
+--
+-- * 'Slack' represents the case where the 'DeltaQ' __meets__
+--   the performance requirements set by the reference point.
+-- * 'Hazard' represents the case where the 'DeltaQ' __fails__ to meet
+--   the performance requirements set by the reference point.
+--
+-- Both cases include information of how far the reference point is
+-- away.
+data SlackOrHazard o
+    = Slack (Duration o) (Probability o)
+    -- ^ We have some slack.
+    -- Specifically, we have 'Duration' at the same probability as the reference,
+    -- and 'Probability' at the same duration as the reference.
+    | Hazard (Eventually (Duration o)) (Probability o)
+    -- ^ We fail to meet the reference point.
+    -- Specifically,
+    -- we overshoot by 'Duration' at the same probability as the reference,
+    -- and by 'Probability' at the same duration as the reference.
+
+deriving instance (Eq (Duration o), Eq (Probability o))
+    => Eq (SlackOrHazard o)
+
+deriving instance (Show (Duration o), Show (Probability o))
+    => Show (SlackOrHazard o)
+
+-- | Test whether the given 'SlackOrHazard' is 'Slack'.
+isSlack :: SlackOrHazard o -> Bool
+isSlack (Slack _ _) = True
+isSlack _ = False
+
+-- | Test whether the given 'SlackOrHazard' is 'Hazard'.
+isHazard :: SlackOrHazard o -> Bool
+isHazard (Hazard _ _) = True
+isHazard _ = False
+
+-- | Compute \"slack or hazard\" with respect to a given reference point.
+meetsRequirement
+    :: DeltaQ o => o -> (Duration o, Probability o) -> SlackOrHazard o
+meetsRequirement o (t,p)
+    | dp >= 0 = Slack dt dp
+    | Abandoned <- t' = Hazard Abandoned (negate dp)
+    | otherwise = Hazard (Occurs $ negate dt) (negate dp)
+  where
+    dp = p' - p
+    dt = t - eventually err id t'
+
+    t' = quantile p o
+    p' = o `successWithin` t
+
+    err = error "distanceToReference: inconsistency"

--- a/lib/deltaq/test/DeltaQ/MethodsSpec.hs
+++ b/lib/deltaq/test/DeltaQ/MethodsSpec.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+{-|
+Copyright   : Predictable Network Solutions Ltd., 2024
+License     : BSD-3-Clause
+Maintainer  : neil.davies@pnsol.com
+-}
+module DeltaQ.MethodsSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import DeltaQ.Class
+    ( Eventually (..)
+    , DeltaQ (..)
+    , Outcome (..)
+    )
+import DeltaQ.PiecewisePolynomial
+    ( DQ
+    )
+import DeltaQ.Methods
+    ( SlackOrHazard (..)
+    , meetsRequirement
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    )
+import Test.QuickCheck
+    ( NonNegative (..)
+    , Positive (..)
+    , property
+    , withMaxSuccess
+    )
+
+{-----------------------------------------------------------------------------
+    Tests
+------------------------------------------------------------------------------}
+spec :: Spec
+spec = do
+    describe "SlackOrHazard" $ do
+        it "never, hazard" $ withMaxSuccess 1 $ property $
+            let deltaq = never :: DQ
+            in  case deltaq `meetsRequirement` (1, 0.9) of
+                    Hazard Abandoned dp -> dp >= 0
+                    _ -> False
+
+        it "uniform, slack" $ property $
+            \(NonNegative r) (Positive d) ->
+                let s = r + d
+                    deltaq = uniform r s :: DQ
+                in  case deltaq `meetsRequirement` (s + d, 0.9) of
+                        Slack dt dp -> dp >= 0 && dt >= 0
+                        _ -> False
+
+        it "uniform, hazard" $ property $
+            \(NonNegative r) (Positive d) ->
+                let s = r + d
+                    deltaq = uniform r s :: DQ
+                in  case deltaq `meetsRequirement` (0, 0.9) of
+                        Hazard (Occurs dt) dp -> dt >= 0 && dp >= 0
+                        _ -> False


### PR DESCRIPTION
This pull request adds a function `meetsRequirement` and a data type `SlackOrHazard` that represents the distance from given reference point in (time, probability) space.

#74 