### PR TITLE
Flip arguments of `quantile`

### DIFF
--- a/doc/examples/01 - Introduction.ipynb
+++ b/doc/examples/01 - Introduction.ipynb
@@ -282,8 +282,8 @@
    "source": [
     "o8 = o7 .>>. o7\n",
     "(\"bounds o8\", asFloat <$> earliest o8, asFloat <$> deadline o8)\n",
-    "(\"median o8\", asFloat <$> quantile 0.5 o8)\n",
-    "(\"90th centile o8\", asFloat <$> quantile 0.9 o8)\n",
+    "(\"median o8\", asFloat <$> quantile o8 0.5)\n",
+    "(\"90th centile o8\", asFloat <$> quantile o8 0.9)\n",
     "(\"prob. within 3.5s\", asFloat $ successWithin o8 3.5)"
    ]
   },
@@ -1185,8 +1185,8 @@
     "o9 = choice 0.75 o8 never\n",
     "\n",
     "(\"bounds o9\", asFloat <$> earliest o9, asFloat <$> deadline o9)\n",
-    "(\"median o9\", asFloat <$> quantile 0.5 o9)\n",
-    "(\"90th centile o9\", asFloat <$> quantile 0.9 o9)\n",
+    "(\"median o9\", asFloat <$> quantile o9 0.5)\n",
+    "(\"90th centile o9\", asFloat <$> quantile o9 0.9)\n",
     "(\"prob. within 3.5s\", asFloat $ successWithin o9 3.5)"
    ]
   },
@@ -2123,8 +2123,8 @@
    "source": [
     "o10 = o9 `firstToFinish` wait 5\n",
     "(\"bounds o10\", asFloat <$> earliest o10, asFloat <$> deadline o10)\n",
-    "(\"median o10\", asFloat <$> quantile 0.5 o10)\n",
-    "(\"90th centile o10\", asFloat <$> quantile 0.9 o10)\n",
+    "(\"median o10\", asFloat <$> quantile o10 0.5)\n",
+    "(\"90th centile o10\", asFloat <$> quantile o10 0.9)\n",
     "(\"prob. within 3.5s\", asFloat $ successWithin o10 3.5)\n",
     "toRenderable $ plotCDFWithQuantiles \"o10 with quantiles\"  [0.25, 0.5, 0.75, 0.9] o10"
    ]

--- a/lib/deltaq/src/DeltaQ/Class.hs
+++ b/lib/deltaq/src/DeltaQ/Class.hs
@@ -204,7 +204,7 @@ class   ( Ord (Probability o)
     --
     -- Return 'Abandoned' if the given probability
     -- exceeds the probability of finishing.
-    quantile :: Probability o -> o -> Eventually (Duration o)
+    quantile :: o -> Probability o -> Eventually (Duration o)
 
     -- | The earliest finish time with non-zero probability.
     --
@@ -316,13 +316,13 @@ equality may be up to numerical accuracy.
 
 'quantile'
 
-> p <= q  implies  quantile p o <= quantile q o
+> p <= q  implies  quantile o p <= quantile o q
 >
-> quantile 0 x        = Occurs 0
-> quantile p never    = Abandoned       if p > 0
-> quantile p (wait t) = Occurs t        if p > 0
+> quantile x        0 = Occurs 0
+> quantile never    p = Abandoned       if p > 0
+> quantile (wait t) p = Occurs t        if p > 0
 >
-> quantile p (uniform r s)  =  r + p*(s-t)  if p > 0, r <= s
+> quantile (uniform r s) p  =  r + p*(s-t)  if p > 0, r <= s
 
 'earliest'
 

--- a/lib/deltaq/src/DeltaQ/Methods.hs
+++ b/lib/deltaq/src/DeltaQ/Methods.hs
@@ -80,7 +80,7 @@ meetsRequirement o (t,p)
     dp = p' - p
     dt = t - eventually err id t'
 
-    t' = quantile p o
+    t' = quantile o p
     p' = o `successWithin` t
 
     err = error "distanceToReference: inconsistency"

--- a/lib/deltaq/src/DeltaQ/PiecewisePolynomial.hs
+++ b/lib/deltaq/src/DeltaQ/PiecewisePolynomial.hs
@@ -147,7 +147,7 @@ instance DeltaQ DQ where
 
     failure (DQ m) = 1 - Measure.total m
 
-    quantile p (DQ m) =
+    quantile (DQ m) p =
         eventuallyFromMaybe
         $ quantileFromMonotone (Measure.distribution m) p
 

--- a/lib/deltaq/src/DeltaQ/Plot.hs
+++ b/lib/deltaq/src/DeltaQ/Plot.hs
@@ -95,7 +95,7 @@ plotCDFWithQuantiles title quantiles o = G.execEC $ do
   where
     cv1 = fromRational . toRational
     cv2 = fromRational . toRational
-    plotQuantile y = case quantile y o of
+    plotQuantile y = case quantile o y of
         Abandoned -> pure ()
         Occurs x -> G.plot $ pure $ focusOnPoint (cv1 x, cv2 y)
 
@@ -168,7 +168,7 @@ plotInverseCDFWithQuantiles title quantiles o = G.execEC $ do
   where
     cv1 = fromRational . toRational
     cv2 = fromRational . toRational
-    plotQuantile y = case quantile y o of
+    plotQuantile y = case quantile o y of
         Abandoned -> pure ()
         Occurs x -> G.plot $ pure $ focusOnPoint (cv1 x, cv2 (1 - y))
 

--- a/lib/deltaq/test/DeltaQ/PiecewisePolynomialSpec.hs
+++ b/lib/deltaq/test/DeltaQ/PiecewisePolynomialSpec.hs
@@ -266,35 +266,35 @@ specProperties = do
                         === successWithin2 r s t
 
     describe "quantile" $ do
-        let quantile' :: Rational -> DQ -> Eventually Rational
+        let quantile' :: DQ -> Rational -> Eventually Rational
             quantile' = quantile
 
         it "0" $ property $
             \o ->
-                quantile' 0 o  ===  Occurs 0
+                quantile' o 0  ===  Occurs 0
 
         it "monotonic" $ property $
             \o (Probability p) (Probability q) ->
                 let p' = min p q
                     q' = max p q
                 in
-                    p' <= q'  ==>  quantile' p' o <= quantile' q' o
+                    p' <= q'  ==>  quantile' o p' <= quantile' o q'
 
         it "never" $ property $
             \(Probability p) ->
                 p > 0 ==>
-                quantile' p never ===  Abandoned
+                quantile' never p  ===  Abandoned
 
         it "wait" $ property $
             \(Probability p) (NonNegative t) ->
                 p > 0 ==>
-                quantile' p (wait t) ===  Occurs t
+                quantile' (wait t) p  ===  Occurs t
 
         it "uniform" $ property $
             \(Probability p) (NonNegative r) (Positive d) ->
                 let s = r + d in 
                 p > 0 ==>
-                quantile' p (uniform r s)
+                quantile' (uniform r s) p
                     === Occurs (r + p*(s-r))
 
     describe "earliest" $ do
@@ -380,7 +380,7 @@ specProperties = do
             in
                 deadline o  ===  Occurs (2^n)
                 .&&. failure o  === 0
-                .&&. quantile (1 - 1/4) o  ===  Occurs 4
+                .&&. quantile o (1 - 1/4)  ===  Occurs 4
 
 specImplementation :: Spec
 specImplementation = do


### PR DESCRIPTION
As a last-minute change to the public API in `Delta.Class`, this pull request changes the order of arguments for the `quantile` function.

This changes enables an optimization when calling `quantile` multiple times for the same outcome.

#78 