### PR TITLE
Test with additional versions of GHC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-# Github action by
+# Github action inspired by
 # https://github.com/jonathanknowles/haskell-example
 #
 name: Build
@@ -12,9 +12,9 @@ on:
   push:
     branches:
       - main
-#  schedule:
+  schedule:
     # Run once per day (at UTC 18:00) to maintain cache:
-#    - cron: 0 18 * * *
+    - cron: 0 18 * * *
 jobs:
   build:
     name: ${{ matrix.os }}-ghc-${{ matrix.ghc }}
@@ -23,25 +23,12 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-#          - macOS-latest
-#          - windows-latest
         cabal:
           - '3.12'
         ghc:
-#          - '8.10'
-#          - '9.0'
-#          - '9.2'
-#          - '9.4'
-#          - '9.6'
-#          - '9.8'
+          - '8.10'
+          - '9.6'
           - '9.10'
-        exclude:
-          # TODO: https://github.com/haskell-actions/setup/issues/77
-          # To work around the above issue, we exclude the following versions:
-          - os: macOS-latest
-            ghc: '8.10'
-          - os: macOS-latest
-            ghc: '9.0'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/lib/deltaq/deltaq.cabal
+++ b/lib/deltaq/deltaq.cabal
@@ -37,6 +37,8 @@ extra-doc-files:
 
 tested-with:
   , GHC == 9.10.1
+  , GHC == 9.6.6
+  , GHC == 8.10.7
 
 common warnings
   ghc-options: -Wall

--- a/lib/probability-polynomial/probability-polynomial.cabal
+++ b/lib/probability-polynomial/probability-polynomial.cabal
@@ -30,6 +30,8 @@ extra-doc-files:
 
 tested-with:
   , GHC == 9.10.1
+  , GHC == 9.6.6
+  , GHC == 8.10.7
 
 common warnings
   ghc-options: -Wall


### PR DESCRIPTION
This pull request adds additional versions of GHC to the test suite in CI.

(Now that the repository is public, we do not run into limits for runners anymore.)