### PR TITLE
Fix `findRoot` not finding root at the midpoint of the interval

### DIFF
--- a/lib/probability-polynomial/src/Numeric/Polynomial/Simple.hs
+++ b/lib/probability-polynomial/src/Numeric/Polynomial/Simple.hs
@@ -592,6 +592,9 @@ findRoot precision (l, u) p
     pu = eval p u
     pl = eval p l
     halveInterval eps x y px py
+        -- if we already have a root, chosse it
+        | px == 0 = x
+        | py == 0 = y
         -- when the interval is small enough, stop:
         -- the root is in this interval, so take the mid point
         | width <= eps = mid

--- a/lib/probability-polynomial/test/Numeric/Polynomial/SimpleSpec.hs
+++ b/lib/probability-polynomial/test/Numeric/Polynomial/SimpleSpec.hs
@@ -217,7 +217,7 @@ spec = do
                 in
                     property $ abs (x2' - x2) <= epsilon
 
-        xit' "bug" "cubic polynomial, midpoint" $ property $ mapSize (`div` 5) $
+        it "cubic polynomial, midpoint" $ property $ mapSize (`div` 5) $
             \(x1 :: Rational) (Positive dx3) ->
                 let xx = scaleX (constant 1) :: Poly Rational
                     x2 = (x1 + x3) / 2


### PR DESCRIPTION
This pull request fixes `findRoot` to return a root that is exactly at the midpoint of the interval.

Fix #69 