### PR TITLE
69 fix findroot bug

### DIFF
--- a/lib/probability-polynomial/src/Numeric/Polynomial/Simple.hs
+++ b/lib/probability-polynomial/src/Numeric/Polynomial/Simple.hs
@@ -585,24 +585,26 @@ findRoot precision (l, u) p
     -- if the polynomial has degree 1, can calculate the root exactly
     | degp == 1 = Just (-(head ps / last ps)) -- p0 + p1x = 0 => x = -p0/p1
     | precision <= 0 = error "Invalid precision value"
-    | otherwise = Just (halveInterval precision l u pl pu)
+    | otherwise = halveInterval precision l u pl pu
   where
     Poly ps = p
     degp = degree p
     pu = eval p u
     pl = eval p l
     halveInterval eps x y px py
-        -- if we already have a root, chosse it
-        | px == 0 = x
-        | py == 0 = y
+        -- if we already have a root, choose it
+        | px == 0 = Just x
+        | py == 0 = Just y
+        | pmid == 0 = Just mid
         -- when the interval is small enough, stop:
         -- the root is in this interval, so take the mid point
-        | width <= eps = mid
-        -- choose the lower half,
-        -- as the polynomial has different signs at the ends
+        | width <= eps = Just mid
+        -- choose the lower half, if the polynomial has different signs at the ends
         | px * pmid < 0 = halveInterval eps x mid px pmid
-        -- choose the upper half
-        | otherwise = halveInterval eps mid y pmid py
+        -- choose the upper half, if the polynomial has different signs at the ends
+        | py * pmid < 0 = halveInterval eps mid y pmid py
+        -- otherwise we have a repeated root, which is also a root of the derivative
+        | otherwise = findRoot precision (x, y) (differentiate p)
       where
         width = y - x
         mid = x + width / 2

--- a/lib/probability-polynomial/src/Numeric/Polynomial/Simple.hs
+++ b/lib/probability-polynomial/src/Numeric/Polynomial/Simple.hs
@@ -189,8 +189,8 @@ Evaluate a polynomial at a point.
 > eval :: Poly a -> a -> a
 -}
 instance Num a => Fun.Function (Poly a) where
-    type instance Domain (Poly a) = a
-    type instance Codomain (Poly a) = a
+    type Domain (Poly a) = a
+    type Codomain (Poly a) = a
     eval = eval
 
 {-|
@@ -228,13 +228,13 @@ We always display the last point as well.
 -}
 display :: (Ord a, Eq a, Num a) => Poly a -> (a, a) -> a -> [(a, a)]
 display p (l, u) s
-  | s == 0 = map evalPoint [l, u]
-  | otherwise = map evalPoint (l : go (l + s))
+    | s == 0 = map evalPoint [l, u]
+    | otherwise = map evalPoint (l : go (l + s))
   where
     evalPoint x = (x, eval p x)
     go x
-      | x >= u = [u] -- always include the last point
-      | otherwise = x : go (x + s)
+        | x >= u = [u] -- always include the last point
+        | otherwise = x : go (x + s)
 
 {-| Linear polymonial connecting the points @(x1, y1)@ and @(x2, y2)@,
 assuming that @x1 ≠ x2@.
@@ -537,13 +537,14 @@ reversedSturmSequence p =
         remainder = snd $ euclidianDivision pIminusOne pI
     go _ = error "reversedSturmSequence: impossible"
 
--- | Check whether a polynomial is monotonically increasing on
--- a given interval.
+{-| Check whether a polynomial is monotonically increasing on
+a given interval.
+-}
 isMonotonicallyIncreasingOn
-    :: (Fractional a, Eq a, Ord a) => Poly a -> (a,a) -> Bool
-isMonotonicallyIncreasingOn p (x1,x2) =
+    :: (Fractional a, Eq a, Ord a) => Poly a -> (a, a) -> Bool
+isMonotonicallyIncreasingOn p (x1, x2) =
     eval p x1 <= eval p x2
-    && countRoots (x1, x2, differentiate p) == 0
+        && countRoots (x1, x2, differentiate p) == 0
 
 {-|
 Measure whether or not a polynomial is consistently above or below zero,
@@ -581,44 +582,48 @@ Constant and linear polynomials, @degree p <= 1@, are treated as special cases.
 -}
 findRoot
     :: forall a. (Fractional a, Eq a, Num a, Ord a) => a -> (a, a) -> Poly a -> Maybe a
-findRoot precision (lower, upper) poly = if null rootFactors then Nothing
-                              else getRoot precision (lower, upper) (head rootFactors)
+findRoot precision (lower, upper) poly =
+    if null rootFactors
+        then Nothing
+        else getRoot precision (lower, upper) (head rootFactors)
   where
-    rootFactors = filter (\x -> countRoots (lower, upper, x) /= 0) (squareFreeFactorisation poly)
-    --getRoot :: forall a. (Fractional a, Eq a, Num a, Ord a) => a -> (a, a) -> Poly a -> Maybe a
+    rootFactors =
+        filter (\x -> countRoots (lower, upper, x) /= 0) (squareFreeFactorisation poly)
+    -- getRoot :: forall a. (Fractional a, Eq a, Num a, Ord a) => a -> (a, a) -> Poly a -> Maybe a
     getRoot eps (l, u) p
-      -- if the polynomial is zero, the whole interval is a root, so return the basepoint
-      | degp < 0 = Just l
-      -- if the poly is a non-zero constant, no root is present
-      | degp == 0 = Nothing
-      -- if the polynomial has degree 1, can calculate the root exactly
-      | degp == 1 = Just (-(head ps / last ps)) -- p0 + p1x = 0 => x = -p0/p1
-      | eps <= 0 = error "Invalid precision value"
-      | otherwise = bisect eps (l, u) (eval p l, eval p u) p
+        -- if the polynomial is zero, the whole interval is a root, so return the basepoint
+        | degp < 0 = Just l
+        -- if the poly is a non-zero constant, no root is present
+        | degp == 0 = Nothing
+        -- if the polynomial has degree 1, can calculate the root exactly
+        | degp == 1 = Just (-(head ps / last ps)) -- p0 + p1x = 0 => x = -p0/p1
+        | eps <= 0 = error "Invalid precision value"
+        | otherwise = bisect eps (l, u) (eval p l, eval p u) p
       where
         ps = toCoefficients p
         degp = degree p
-        {- We bisect the interval exploiting the Intermediate Value Theorem: 
+        {- We bisect the interval exploiting the Intermediate Value Theorem:
         if a polynomial has different signs at the ends of an interval, it must be zero somewhere in the interval.
         If there is no change of sign, use countRoots to find which side of the interval the root is on.
         -}
-        bisect :: (Fractional a, Eq a, Num a, Ord a) => a -> (a, a) -> (a, a) -> Poly a -> Maybe a
+        bisect
+            :: (Fractional a, Eq a, Num a, Ord a) => a -> (a, a) -> (a, a) -> Poly a -> Maybe a
         bisect e (x, y) (px, py) p'
-          -- if we already have a root, choose it
-          | px == 0 = Just x
-          | py == 0 = Just y
-          | pmid == 0 = Just mid
-          -- when the interval is small enough, stop:
-          -- the root is in this interval, so take the mid point
-          | width <= e = Just mid
-          -- choose the lower half, if the polynomial has different signs at the ends
-          | signum px /= signum pmid = bisect e (x, mid) (px, pmid) p'
-          -- choose the upper half, if the polynomial has different signs at the ends
-          | signum py /= signum pmid = bisect e (mid, y) (pmid, py) p'
-          -- no sign change found, so we resort to counting roots
-          | countRoots (x, mid, p') > 0 = bisect e (x, mid) (px, pmid) p'
-          | countRoots (mid, y, p') > 0 = bisect e (mid, y) (pmid, py) p'
-          | otherwise = Nothing
+            -- if we already have a root, choose it
+            | px == 0 = Just x
+            | py == 0 = Just y
+            | pmid == 0 = Just mid
+            -- when the interval is small enough, stop:
+            -- the root is in this interval, so take the mid point
+            | width <= e = Just mid
+            -- choose the lower half, if the polynomial has different signs at the ends
+            | signum px /= signum pmid = bisect e (x, mid) (px, pmid) p'
+            -- choose the upper half, if the polynomial has different signs at the ends
+            | signum py /= signum pmid = bisect e (mid, y) (pmid, py) p'
+            -- no sign change found, so we resort to counting roots
+            | countRoots (x, mid, p') > 0 = bisect e (x, mid) (px, pmid) p'
+            | countRoots (mid, y, p') > 0 = bisect e (mid, y) (pmid, py) p'
+            | otherwise = Nothing
           where
             width = y - x
             mid = x + width / 2
@@ -627,7 +632,7 @@ findRoot precision (lower, upper) poly = if null rootFactors then Nothing
 {-| We are seeking the point at which a polynomial has a specific value.:
 subtract the value we are looking for so that we seek a zero crossing
 -}
-root --TODO: this should probably be called something else such as 'findCrossing'
+root -- TODO: this should probably be called something else such as 'findCrossing'
     :: (Ord a, Num a, Eq a, Fractional a)
     => a
     -> a
@@ -637,7 +642,8 @@ root --TODO: this should probably be called something else such as 'findCrossing
 root e x (l, u) p = findRoot e (l, u) (p - constant x)
 
 -- | Greatest monic common divisor of two polynomials.
-gcdPoly :: forall a. (Fractional a, Eq a, Num a, Ord a) => Poly a -> Poly a -> Poly a
+gcdPoly
+    :: forall a. (Fractional a, Eq a, Num a, Ord a) => Poly a -> Poly a -> Poly a
 gcdPoly a b = if b == zero then a else makeMonic (gcdPoly b (polyRemainder a b))
   where
     makeMonic :: Poly a -> Poly a
@@ -647,8 +653,8 @@ gcdPoly a b = if b == zero then a else makeMonic (gcdPoly b (polyRemainder a b))
 
 {-|
 We compute the square-free factorisation of a polynomial using Yun's algorithm.
-Yun, David Y.Y. (1976). "On square-free decomposition algorithms". 
-SYMSAC '76 Proceedings of the third ACM Symposium on Symbolic and Algebraic Computation. 
+Yun, David Y.Y. (1976). "On square-free decomposition algorithms".
+SYMSAC '76 Proceedings of the third ACM Symposium on Symbolic and Algebraic Computation.
 Association for Computing Machinery. pp. 26–35. doi:10.1145/800205.806320. ISBN 978-1-4503-7790-4. S2CID 12861227.
 https://dl.acm.org/doi/10.1145/800205.806320
 G <- gcd (P, P')

--- a/lib/probability-polynomial/src/Numeric/Polynomial/Simple.hs
+++ b/lib/probability-polynomial/src/Numeric/Polynomial/Simple.hs
@@ -600,7 +600,7 @@ findRoot precision (lower, upper) poly = if null rootFactors then Nothing
         degp = degree p
         {- We bisect the interval exploiting the Intermediate Value Theorem: 
         if a polynomial has different signs at the ends of an interval, it must be zero somewhere in the interval.
-        If there is no change of sign, use use countRoots to find which side of the interval the root is on.
+        If there is no change of sign, use countRoots to find which side of the interval the root is on.
         -}
         bisect :: (Fractional a, Eq a, Num a, Ord a) => a -> (a, a) -> (a, a) -> Poly a -> Maybe a
         bisect e (x, y) (px, py) p'
@@ -618,7 +618,7 @@ findRoot precision (lower, upper) poly = if null rootFactors then Nothing
           -- no sign change found, so we resort to counting roots
           | countRoots (x, mid, p') > 0 = bisect e (x, mid) (px, pmid) p'
           | countRoots (mid, y, p') > 0 = bisect e (mid, y) (pmid, py) p'
-          | otherwise = error "findRoot: No root found"
+          | otherwise = Nothing
           where
             width = y - x
             mid = x + width / 2

--- a/lib/probability-polynomial/test/Numeric/Polynomial/SimpleSpec.hs
+++ b/lib/probability-polynomial/test/Numeric/Polynomial/SimpleSpec.hs
@@ -228,6 +228,19 @@ spec = do
                     epsilon = (x3-x1)/(1000*1000*50)
                     Just x2' = root epsilon 0 (l, u) p
                 in
+                    abs (x2' - x2) <= epsilon
+
+        it "quartic polynomial, double root" $ property $ mapSize (`div` 5) $
+            \(x1 :: Rational) (Positive dx3) ->
+                let xx = scaleX (constant 1) :: Poly Rational
+                    x2 = (x1 + x3) / 2
+                    x3 = x1 + dx3
+                    p = xx * (xx - constant x1) * (xx - constant x2) * (xx - constant x3)
+                    l = x1 + 1002 * epsilon
+                    u = x3 - 1000 * epsilon
+                    epsilon = (x3-x1)/(1000*1000*50)
+                    Just x2' = root epsilon 0 (l, u) p
+                in
                     id
                     $ counterexample ("interval = " <> show (l,u))
                     $ counterexample ("countRoots = " <> show (countRoots (l, u, p)))

--- a/lib/probability-polynomial/test/Numeric/Polynomial/SimpleSpec.hs
+++ b/lib/probability-polynomial/test/Numeric/Polynomial/SimpleSpec.hs
@@ -45,22 +45,18 @@ import Numeric.Polynomial.Simple
     )
 import Test.Hspec
     ( Spec
-    , before_
     , describe
     , it
-    , pendingWith
     )
 import Test.QuickCheck
     ( Arbitrary
     , Gen
     , NonNegative (..)
     , Positive (..)
-    , Property
     , (===)
     , (==>)
     , (.&&.)
     , arbitrary
-    , counterexample
     , forAll
     , frequency
     , listOf
@@ -74,9 +70,6 @@ import qualified Test.QuickCheck as QC
 {-----------------------------------------------------------------------------
     Tests
 ------------------------------------------------------------------------------}
-xit' :: String -> String -> Property -> Spec
-xit' reason label = before_ (pendingWith reason) . it label
-
 spec :: Spec
 spec = do
     describe "constant" $ do
@@ -230,26 +223,16 @@ spec = do
                 in
                     abs (x2' - x2) <= epsilon
 
-        it "quartic polynomial, double root" $ property $ mapSize (`div` 5) $
-            \(x1 :: Rational) (Positive dx3) ->
+        it "high-degree polynomial, repeated root" $ property $ mapSize (`div` 5) $
+            \(Positive (x1 :: Rational)) (Positive (n :: Integer)) ->
                 let xx = scaleX (constant 1) :: Poly Rational
-                    x2 = (x1 + x3) / 2
-                    x3 = x1 + dx3
-                    p = xx * (xx - constant x1) * (xx - constant x2) * (xx - constant x3)
-                    l = x1 + 1002 * epsilon
-                    u = x3 - 1000 * epsilon
-                    epsilon = (x3-x1)/(1000*1000*50)
+                    p = xx*(xx - constant x1)^n
+                    l = x1 - 100 * epsilon
+                    u = x1 + 100 * epsilon
+                    epsilon = x1/(1000*1000*50)
                     Just x2' = root epsilon 0 (l, u) p
                 in
-                    id
-                    $ counterexample ("interval = " <> show (l,u))
-                    $ counterexample ("countRoots = " <> show (countRoots (l, u, p)))
-                    $ counterexample ("expected root = " <> show x2)
-                    $ counterexample ("eval polynomial at expected root = " <> show (eval p x2))
-                    $ counterexample ("epsilon = " <> show epsilon)
-                    $ counterexample ("found root = " <> show x2')
-                    $ counterexample ("root within range of other root " <> show (abs (x2' - x3) <= 20*epsilon))
-                    $ property $ abs (x2' - x2) <= epsilon
+                    abs (x2' - x1) <= epsilon
 
     describe "isMonotonicallyIncreasingOn" $
         it "quadratic polynomial" $ property $


### PR DESCRIPTION
This PR improves the function findRoot to deal with repeated roots properly by first finding a square-free factorisation of the polynomial before engaging in interval-bisecting to find the root. It also removes a test that was failing due to violating the precondition for findRoot and adds one to test the repeated-root finding.