### PR TITLE
Bump to allow `containers-0.8`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-index-state: 2024-10-26T10:13:37Z
+index-state: 2025-03-01T13:51:25Z
 
 packages:
     lib/deltaq/

--- a/cabal.project
+++ b/cabal.project
@@ -6,3 +6,13 @@ packages:
 
 tests:
   True
+
+--
+-- Use `contraints` and `allow-newer` to test against
+-- a new release of a dependency.
+--
+-- constraints:
+--    containers == 0.8
+--
+-- allow-newer:
+--    *:containers

--- a/lib/probability-polynomial/probability-polynomial.cabal
+++ b/lib/probability-polynomial/probability-polynomial.cabal
@@ -48,7 +48,7 @@ library
 
   build-depends:
     , base >= 4.14.3.0 && < 5
-    , containers >= 0.6 && < 0.8
+    , containers >= 0.6 && < 0.9
     , deepseq >= 1.4.4.0 && < 1.6
     , exact-combinatorics >= 0.2 && < 0.3
 


### PR DESCRIPTION
This pull request bumps the version constraints on dependencies to allow the newly released package `containers-0.8`.