### PR TITLE
113 make square free factorisation more robust

### DIFF
--- a/lib/probability-polynomial/src/Numeric/Polynomial/Simple.hs
+++ b/lib/probability-polynomial/src/Numeric/Polynomial/Simple.hs
@@ -677,7 +677,7 @@ squareFreeFactorisation p =
     d1 = (diffP `divide` g0) - differentiate c1
     divide x y = fst (euclidianDivision x y)
     go c d
-        | c == constant 1 = [] -- terminate the recursion
+        | degree c  == 0 = [] -- terminate the recursion
         | degree a' == 0 = go c' d' -- skip over constant polynomials
         | otherwise = a' : go c' d'
       where

--- a/lib/probability-polynomial/src/Numeric/Polynomial/Simple.hs
+++ b/lib/probability-polynomial/src/Numeric/Polynomial/Simple.hs
@@ -678,7 +678,7 @@ squareFreeFactorisation p =
     divide x y = fst (euclidianDivision x y)
     go c d
         | c == constant 1 = [] -- terminate the recursion
-        | a' == constant 1 = go c' d' -- skip over the constant polynomial
+        | degree a' == 0 = go c' d' -- skip over constant polynomials
         | otherwise = a' : go c' d'
       where
         a' = gcdPoly c d


### PR DESCRIPTION
Replacing tests for precise equality of a polynomial with the constant value 1 with a check that the degree of the polynomial is 0 (i.e. it is a constant) avoids potential failures due to numerical imprecision.