### PR TITLE
Allow newer `QuickCheck` and `optparse-applicative`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-index-state: 2025-03-01T13:51:25Z
+index-state: 2025-07-02T07:56:17Z
 
 packages:
     lib/deltaq/
@@ -11,8 +11,10 @@ tests:
 -- Use `contraints` and `allow-newer` to test against
 -- a new release of a dependency.
 --
+
 -- constraints:
---    containers == 0.8
+--  , optparse-applicative == 0.19.0.0
+--  , QuickCheck == 2.16.0.0
 --
 -- allow-newer:
 --    *:containers

--- a/lib/deltaq/deltaq.cabal
+++ b/lib/deltaq/deltaq.cabal
@@ -79,7 +79,7 @@ test-suite test
     , deltaq
     , probability-polynomial
     , hspec >= 2.11.0 && < 2.12
-    , QuickCheck >= 2.14 && < 2.16
+    , QuickCheck >= 2.14 && < 2.17
 
   main-is:
     Spec.hs
@@ -103,7 +103,7 @@ benchmark basic
     , criterion >= 1.6 && < 1.7
     , deepseq
     , hvega >= 0.12 && < 0.13
-    , optparse-applicative >= 0.18.1.0 && < 0.19
+    , optparse-applicative >= 0.18.1.0 && < 0.20
     , statistics >= 0.16 && < 0.17
     , vector >= 0.12 && < 0.14
 

--- a/lib/probability-polynomial/probability-polynomial.cabal
+++ b/lib/probability-polynomial/probability-polynomial.cabal
@@ -74,7 +74,7 @@ test-suite test
     , containers
     , probability-polynomial
     , hspec >= 2.11.0 && < 2.12
-    , QuickCheck >= 2.14 && < 2.16
+    , QuickCheck >= 2.14 && < 2.17
   
   main-is:
     Spec.hs


### PR DESCRIPTION
This pull request allows newer versions of dependencies.