### PR TITLE
Add data type `O` for outcome expressions

### DIFF
--- a/lib/deltaq/CHANGELOG.md
+++ b/lib/deltaq/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 1.0.2.0 — to be released
 
-* Add `DeltaQ.Diagram` for rendering outcomes as diagrams.
+* Add `DeltaQ.Diagram` for rendering outcome expressions as diagrams.
+* Add `DeltaQ.Expr` with a data type `O` for outcome expressions.
 
 ## 1.0.1.0 — 2025-09-26
 

--- a/lib/deltaq/deltaq.cabal
+++ b/lib/deltaq/deltaq.cabal
@@ -64,6 +64,7 @@ library
     DeltaQ
     DeltaQ.Class
     DeltaQ.Diagram
+    DeltaQ.Expr
     DeltaQ.Methods
     DeltaQ.PiecewisePolynomial
     DeltaQ.Plot

--- a/lib/deltaq/src/DeltaQ/Class.hs
+++ b/lib/deltaq/src/DeltaQ/Class.hs
@@ -228,6 +228,8 @@ the following properties.
 For instances that use approximate arithmetic
 such as floating point arithmetic or fixed precision arithmetic,
 equality may be up to numerical accuracy.
+
+#p:Outcome#
 -}
 
 {-$properties-outcome

--- a/lib/deltaq/src/DeltaQ/Diagram.hs
+++ b/lib/deltaq/src/DeltaQ/Diagram.hs
@@ -54,7 +54,7 @@ data Tile = Tile X Y Token
 
 -- | Render a collection of tiles.
 renderTiles :: [Tile] -> Diagram SVG
-renderTiles = position . map renderTile
+renderTiles = frame 0.1 . position . map renderTile
   where
     renderTile (Tile x y token) =
         ( p2 (fromIntegral x, negate $ fromIntegral y)
@@ -64,8 +64,9 @@ renderTiles = position . map renderTile
 -- | Render a single 'Token' associated with a 'Tile'.
 renderToken :: Token -> Diagram SVG
 renderToken (VarT s)     =
-    (circle 0.44 & lc orange & lw 4)
-    <> scale 0.3 (text s)
+    scale 0.3 (text s)
+    <> (circle 0.44 & lc orange & lw 4 & fc white)
+    <> hrule 1
 renderToken Horizontal   = hrule 1
 renderToken (Close ds)   =
     mconcat (map (renderLine . fromIntegral . negate) ds)

--- a/lib/deltaq/src/DeltaQ/Diagram.hs
+++ b/lib/deltaq/src/DeltaQ/Diagram.hs
@@ -11,26 +11,32 @@ Render outcome expressions as outcome diagrams.
 module DeltaQ.Diagram
     ( -- * Outcome diagrams
       renderOutcomeDiagram
-
-    -- * Outcome expressions
-    , Expr (..)
-    , var
-    , maxParallel
     ) where
 
-import Prelude hiding (last, seq)
-
+import DeltaQ.Class
+    ( Outcome (..)
+    )
+import DeltaQ.Expr
+    ( O
+    , var
+    , Term (..)
+    , isParallel
+    , isSeq
+    , isVar
+    , maxParallel
+    , termFromOutcome
+    )
 import Diagrams.Prelude hiding (First, Last, op)
 import Diagrams.Backend.SVG
 
-out :: Expr String -> IO ()
+out :: O -> IO ()
 out =
     renderSVG "xoutcomes.svg" (mkWidth 700)
     . renderOutcomeDiagram
 
 -- | Render an outcome expression as an outcome diagram.
-renderOutcomeDiagram :: Expr String -> Diagram SVG
-renderOutcomeDiagram = renderTiles . layout
+renderOutcomeDiagram :: O -> Diagram SVG
+renderOutcomeDiagram = renderTiles . layout . termFromOutcome
 
 {-----------------------------------------------------------------------------
     Diagram rendering
@@ -79,8 +85,8 @@ renderToken (Open op ds) =
     <> hrule 1
   where
     renderOp :: Op -> Diagram SVG
-    renderOp OFirst = text "∀"
-    renderOp OLast  = text "∃"
+    renderOp OFirst = text "∃"
+    renderOp OLast  = text "∀"
 
     renderLine d = fromVertices [p2 (0, 0), p2 (0.5, d)] & strokeLine
 
@@ -105,10 +111,10 @@ and the root to the right, like this:
 
 -}
 
-type EdgeData = (Y, Maybe (Expr String))
+type EdgeData = (Y, Maybe (Term String))
 
 -- | Layout an outcome diagram.
-layout :: Expr String -> [Tile]
+layout :: Term String -> [Tile]
 layout t = go 0 $ twig (0, Just t)
   where
     go !x0 s0
@@ -292,87 +298,25 @@ updateFoliage f (Branch bs) = Branch $ concatMap update bs
     update (x, Branch cs) = [(x, Branch $ concatMap update cs)]
 
 {-----------------------------------------------------------------------------
-    Exprs
+    Example expressions
 ------------------------------------------------------------------------------}
--- | Outcome expressions.
-data Expr v
-    = Var v
---    | Never
---    | Wait Rational
-    | Seq [Expr v]
-        -- invariant: list nonempty
-        -- invariant: items of the list are not seqs.
-    | Last [Expr v]
-    | First [Expr v]
---  | Choice loc [Expr v]
-    deriving (Show, Eq, Ord)
-
--- | Smart constructor for 'Var'.
-var :: v -> Expr v
-var = Var
-
--- | Smart constructor for sequential composition.
-seq :: [Expr v] -> Expr v
-seq = Seq . concatMap pop
-  where
-    pop (Seq ts) = ts
-    pop t = [t]
-
--- | Smart constructor for last-to-finish.
-last :: [Expr v] -> Expr v
-last = Last . concatMap pop
-  where
-    pop (Last ts) = ts
-    pop t = [t]
-
--- | Smart constructor for first-to-finish.
-first :: [Expr v] -> Expr v
-first = First . concatMap pop
-  where
-    pop (Last ts) = ts
-    pop t = [t]
-
--- | Check whether a 'Expr' is a 'Seq'.
-isSeq :: Expr v -> Bool
-isSeq (Seq _) = True
-isSeq _       = False
-
--- | Check whether a 'Expr' is a 'Var'.
-isVar :: Expr v -> Bool
-isVar (Var _) = True
-isVar _       = False
-
--- | Check whether a 'Expr' is a parallel operation.
-isParallel :: Expr v -> Bool
-isParallel (First ts) = not (null ts)
-isParallel (Last  ts) = not (null ts)
-isParallel _          = False
-
--- | Maximal number of outcomes that run in parallel.
-maxParallel :: Expr v -> Int
-maxParallel (Var   _) = 1
-maxParallel (Seq   ts) = maximum (map maxParallel ts)
-maxParallel (Last  ts) = sum (map maxParallel ts)
-maxParallel (First ts) = sum (map maxParallel ts)
-
-example1 :: Expr String
+example1 :: O
 example1 =
-    last
-        [ var "AZ"
-        , seq [var "AB", last [var "BZ", seq [var "BC", var "CZ"]]]
-        ]
+    var "AZ"
+    ./\. (var "AB" .>>. (var "BZ" .\/. (var "BC" .>>. var "CZ")))
 
-example2 :: Expr String
+example2 :: O
 example2 =
-    seq
-        [ var "AB"
-        , first [var "BX", seq [ var "BC", var "CX" ] ]
-        , var "XY"
-        , last [var "YZ", seq [ var "YQ", var "QZ" ] ]
-        ]
+    var "AB"
+    .>>. (var "BX" .\/. (var "BC" .>>. var "CX"))
+    .>>. var "XY"
+    .>>. (var "YZ" .\/. (var "YQ" .>>. var "QZ"))
 
-exampleS :: Expr String
-exampleS = seq [ first [var "S1", var "S2"], var "S3" ]
+exampleS :: O
+exampleS = (var "S1" .\/. var "S2") .>>. var "S3"
 
-example3 :: Expr String
-example3 = last [seq [exampleS, exampleS], exampleS, seq [example1, var "ZQ"]]
+example3 :: O
+example3 =
+    (exampleS .>>. exampleS)
+    .\/. exampleS
+    .\/. (example1 .>>. var "ZQ")

--- a/lib/deltaq/src/DeltaQ/Expr.hs
+++ b/lib/deltaq/src/DeltaQ/Expr.hs
@@ -31,6 +31,12 @@ module DeltaQ.Expr
     , termFromOutcome
     , outcomeFromTerm
     , Term (..)
+    , isVar
+    , isSeq
+    , isLast
+    , isFirst
+    , isParallel
+    , maxParallel
     , everywhere
     , isNormalizedAssoc
     , normalizeAssoc
@@ -176,17 +182,39 @@ isNormalizedAssoc (First xs) =
 isNormalizedAssoc _ =
     True
 
+-- | Check whether a 'Term' is a 'Var'.
+isVar :: Term v -> Bool
+isVar (Var _) = True
+isVar _       = False
+
+-- | Check whether a 'Term' is a 'Seq'.
 isSeq :: Term v -> Bool
 isSeq (Seq _) = True
 isSeq _ = False
 
+-- | Check whether a 'Term' is a 'Last'.
 isLast :: Term v -> Bool
 isLast (Last _) = True
 isLast _ = False
 
+-- | Check whether a 'Term' is a 'First'.
 isFirst :: Term v -> Bool
 isFirst (First _) = True
 isFirst _ = False
+
+-- | Check whether a 'Term' is a parallel operation,
+-- i.e. 'Last' or 'First'.
+isParallel :: Term v -> Bool
+isParallel (First ts) = not (null ts)
+isParallel (Last  ts) = not (null ts)
+isParallel _          = False
+
+-- | Maximal number of outcomes that run in parallel.
+maxParallel :: Term v -> Int
+maxParallel (Seq   ts) = maximum (map maxParallel ts)
+maxParallel (Last  ts) = sum (map maxParallel ts)
+maxParallel (First ts) = sum (map maxParallel ts)
+maxParallel _          = 1
 
 -- | Normalize a term to \"associative normal form\".
 normalizeAssoc :: Term v -> Term v

--- a/lib/deltaq/src/DeltaQ/Expr.hs
+++ b/lib/deltaq/src/DeltaQ/Expr.hs
@@ -1,0 +1,247 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+
+{-|
+Copyright   :
+    Predictable Network Solutions Ltd., 2020-2024
+    PLWORKZ R&D, 2025
+License     : BSD-3-Clause
+Description : Outcome expressions.
+
+The type 'O' represents outcome expressions that can be
+
+* inspected,
+* rendered as outcome diagrams, and
+* converted to a probability distribution of completion times.
+
+-}
+module DeltaQ.Expr
+    ( -- * Outcome expressions
+      O
+    , var
+    , substitute
+    , toDeltaQ
+
+    -- * Outcome terms
+    , termFromOutcome
+    , outcomeFromTerm
+    , Term (..)
+    , everywhere
+    , isNormalizedAssoc
+    , normalizeAssoc
+    ) where
+
+import Control.Monad
+    ( ap
+    )
+import Control.DeepSeq
+    ( NFData
+    )
+import DeltaQ.Class
+    ( Outcome (..)
+    )
+import DeltaQ.PiecewisePolynomial
+    ( DQ
+    )
+import GHC.Generics
+    ( Generic
+    )
+
+{-----------------------------------------------------------------------------
+    O
+------------------------------------------------------------------------------}
+-- | Outcome expression.
+--
+-- This type includes graphical annotations for the rendering
+-- as outcome diagram.
+newtype O = O { unO :: Term String }
+    -- INVARIANT: Terms satisfy 'isNormalizedAssoc'.
+    deriving (Show, Generic, NFData)
+
+-- | Outcome variable, given by a unique name.
+var :: String -> O
+var = O . Var
+
+-- | Substitute all variables by outcome expressions.
+substitute
+    :: (String -> O)
+        -- ^ Assignment of variable names to outcome expressions.
+    -> O
+        -- ^ Outcome expression in which we substitute.
+    -> O
+substitute f (O term) = O $ normalize1Assoc $ term >>= unO . f
+
+-- | Outcome expressions can be mapped to
+-- probability distributions of completion times 'DQ',
+-- provided that we know how to map 'var'.
+toDeltaQ :: (String -> DQ) -> O -> DQ
+toDeltaQ f (O term) = go term
+  where
+    go (Var v) = f v
+    go Never = never
+    go Wait0 = wait 0
+    go (Wait t) = wait t
+    go (Seq   xs) = foldr1 (.>>.) $ map go xs
+    go (Last  xs) = foldr1 (./\.) $ map go xs
+    go (First xs) = foldr1 (.\/.) $ map go xs
+
+-- | Outcome expressions are instances of 'Outcome'.
+instance Outcome O where
+    type Duration O = Rational
+
+    never = O Never
+    wait = O . Wait
+    sequentially  (O x) (O y) = O . normalize1Assoc $ Seq [x,y]
+    firstToFinish (O x) (O y) = O . normalize1Assoc $ First [x,y]
+    lastToFinish  (O x) (O y) = O . normalize1Assoc $ Last [x,y]
+
+{-----------------------------------------------------------------------------
+    Terms
+------------------------------------------------------------------------------}
+-- | Term representation for outcome expressions.
+--
+-- Different terms may represent equal outcomes.
+data Term v
+    = Var v
+        -- ^ Variable, to be substituted by a more concrete outcome.
+    | Never
+        -- ^ Outcome that never finishes.
+    | Wait0
+        -- ^ Succeed immediately. Equivalent to @Wait 0@,
+        -- but with a straight line as graphical representation.
+    | Wait Rational
+        -- ^ Succeed after waiting for a fixed amount of time.
+    | Seq [Term v]
+        -- ^ Sequential composition.
+    | Last [Term v]
+        -- ^ Parallel composition, last to finish.
+    | First [Term v]
+        -- ^ Parallel composiiton, last to finish.
+    deriving (Show, Eq, Ord, Generic, Functor, NFData)
+
+instance Applicative Term where
+    pure = Var
+    (<*>) = ap
+
+-- | '(>>=)' is substitution.
+instance Monad Term where
+    m >>= g = go m
+      where
+        go (Var v)    = g v
+        go Never      = Never
+        go Wait0      = Wait0
+        go (Wait t)   = Wait t
+        go (Seq   xs) = Seq   $ map go xs
+        go (Last  xs) = Last  $ map go xs
+        go (First xs) = First $ map go xs
+
+-- | Inspect an outcome expression 'O' through its 'Term' representation.
+--
+-- The result 'Term' satisfies 'isNormalizedAssoc'.
+termFromOutcome :: O -> Term String
+termFromOutcome (O term) = term
+
+-- | Construct an outcome expression 'O' from an outcome 'Term'.
+outcomeFromTerm :: Term String -> O
+outcomeFromTerm = O . normalizeAssoc
+
+-- | Predicate that defines the \"associative normal form\" for a 'Term'.
+--
+-- Specifically, a 'Term' is said to be in \"associative normal form\"
+-- if the arguments to the constructors 'Seq', 'Last', and 'First'
+--
+-- * are nonempty lists, and
+-- * their list elements do not have an outermost constructor of the same
+--   kind, i.e. @Seq [Seq …, First …]@ is not allowed because
+--   one of the list elements for a 'Seq' constructor
+--   is also a 'Seq' constructor.
+isNormalizedAssoc ::Term v -> Bool 
+isNormalizedAssoc (Seq xs) =
+    not (null xs)
+    && all (not . isSeq) xs
+    && all isNormalizedAssoc xs
+isNormalizedAssoc (Last xs) =
+    not (null xs)
+    && all (not . isLast) xs
+    && all isNormalizedAssoc xs
+isNormalizedAssoc (First xs) =
+    not (null xs)
+    && all (not . isFirst) xs
+    && all isNormalizedAssoc xs
+isNormalizedAssoc _ =
+    True
+
+isSeq :: Term v -> Bool
+isSeq (Seq _) = True
+isSeq _ = False
+
+isLast :: Term v -> Bool
+isLast (Last _) = True
+isLast _ = False
+
+isFirst :: Term v -> Bool
+isFirst (First _) = True
+isFirst _ = False
+
+-- | Normalize a term to \"associative normal form\".
+normalizeAssoc :: Term v -> Term v
+normalizeAssoc = everywhere normalize1Assoc
+
+-- | Apply a transformation everywhere; bottom-up.
+--
+-- See also [Scrap your boilerplate
+-- ](https://www.microsoft.com/en-us/research/wp-content/uploads/2003/01/hmap.pdf)
+-- .
+everywhere :: (Term v -> Term v) -> Term v -> Term v
+everywhere f = every
+  where
+    every = f . recurse
+
+    recurse a@(Var _) = a
+    recurse a@Never = a
+    recurse a@Wait0 = a
+    recurse a@(Wait _) = a
+    recurse (Seq   xs) = Seq $ map every xs
+    recurse (Last  xs) = Last $ map every xs
+    recurse (First xs) = First $ map every xs
+
+-- | Normalize a term to \"associative normal form\"
+-- under the assumptions
+-- that the arguments to the outermost constructor are already normalized.
+normalize1Assoc :: Term v -> Term v
+normalize1Assoc = id
+    . normalizeEmpty
+    . normalize1Assoc'
+
+-- | Ensure that the lists in 'Seq', 'Last', 'First'
+-- do not contain a term with the same constructor.
+normalizeEmpty :: Term v -> Term v
+normalizeEmpty (Seq   []) = Wait0
+normalizeEmpty (Last  []) = Wait0
+normalizeEmpty (First []) = Wait0
+normalizeEmpty x = x
+
+-- | Ensure that the lists in 'Seq', 'Last', 'First'
+-- do not contain a term with the same constructor.
+normalize1Assoc' :: Term v -> Term v
+normalize1Assoc' (Seq xs) = Seq (concatMap f xs)
+  where
+    f Wait0 = []
+    f (Seq ys) = ys
+    f o = [o]
+normalize1Assoc' (Last xs) = Last (concatMap f xs)
+  where
+    f Wait0 = []
+    f (Last ys) = ys
+    f o = [o]
+normalize1Assoc' (First xs) = First (concatMap f xs)
+  where
+    f Wait0 = []
+    f (First ys) = ys
+    f o = [o]
+normalize1Assoc' o = o


### PR DESCRIPTION
This pull requests adds outcome expressions in a new module `DeltaQ.Expr`.

The data type `O` represents outcome expressions. It is an instance of the type class `Outcome`, which allows us to use syntax such as `./\.` for operations. However, the type `O` does not satisfy the properties listed for the class `Outcome`, as it represents unnormalized expressions and does not have an `Eq` instance.