### PR TITLE
Add constructor `Uniform` to `Term`

### DIFF
--- a/lib/deltaq/src/DeltaQ/Diagram/Internal.hs
+++ b/lib/deltaq/src/DeltaQ/Diagram/Internal.hs
@@ -57,6 +57,7 @@ data Op0
     = ONever
     | OWait0
     | OWait Rational
+    | OUniform Rational Rational
     deriving (Eq, Ord, Show)
 
 -- | Data attached to a 'Tile'.
@@ -147,6 +148,11 @@ renderOp0Symbol OWait0    = mempty
 renderOp0Symbol (OWait t) =
     textInWidth 1 $
         "wait " <> printf "%.2f" (fromRational t :: Double)
+renderOp0Symbol (OUniform tl tr) =
+    textInWidth 1 $
+        "uniform "
+            <> printf "%.2f" (fromRational tl :: Double) <> " "
+            <> printf "%.2f" (fromRational tr :: Double)
 
 -- | Render the symbol that represents an operation with multiple arguments
 renderOpSymbol :: Op -> Diagram SVG
@@ -238,6 +244,7 @@ isVarOrKnown (Var _)  = True
 isVarOrKnown Never    = True
 isVarOrKnown Wait0    = True
 isVarOrKnown (Wait _) = True
+isVarOrKnown (Uniform _ _) = True
 isVarOrKnown _ = False
 
 -- | Check that a given 'EdgeData' contains no outcome-related data.
@@ -285,6 +292,7 @@ emitVar x s =
     emit (y, Term Never    _) = Tile x y $ Outcome ONever
     emit (y, Term Wait0    _) = Tile x y $ Outcome OWait0
     emit (y, Term (Wait t) _) = Tile x y $ Outcome $ OWait t
+    emit (y, Term (Uniform tl tr) _) = Tile x y $ Outcome $ OUniform tl tr
     emit (y, _              ) = Tile x y Horizontal
 
 -- | Emit a column with the next vertical items.

--- a/lib/deltaq/src/DeltaQ/Expr.hs
+++ b/lib/deltaq/src/DeltaQ/Expr.hs
@@ -57,6 +57,7 @@ import Data.List
     )
 import DeltaQ.Class
     ( Outcome (..)
+    , DeltaQ (..)
     , ProbabilisticOutcome (..)
     )
 import DeltaQ.PiecewisePolynomial
@@ -108,6 +109,7 @@ toDeltaQ f (O term) = go term
     go Never    = never
     go Wait0    = wait 0
     go (Wait t) = wait t
+    go (Uniform tl tr) = uniform tl tr
     go (Loc  _) = wait 0
     go (Seq   xs) = foldr1 (.>>.) $ map go xs
     go (Last  xs) = foldr1 (./\.) $ map go xs
@@ -147,6 +149,9 @@ data Term v
         -- but with a straight line as graphical representation.
     | Wait Rational
         -- ^ Succeed after waiting for a fixed amount of time.
+    | Uniform Rational Rational
+        -- ^ @Uniform l r@ succeeds after an amount of time randomly drawn
+        -- from a uniform probability distribution on the interval $[l,r]$.
     | Loc String
         -- ^ Outcome location with a label.
         -- Equivalent to @Wait 0@, but with a labeled box
@@ -174,6 +179,7 @@ instance Monad Term where
         go Never      = Never
         go Wait0      = Wait0
         go (Wait t)   = Wait t
+        go (Uniform tl tr) = Uniform tl tr
         go (Loc  s)   = Loc s
         go (Seq   xs) = Seq   $ map go xs
         go (Last  xs) = Last  $ map go xs
@@ -290,6 +296,7 @@ everywhere f = every
     recurse a@Never = a
     recurse a@Wait0 = a
     recurse a@(Wait _) = a
+    recurse a@(Uniform _ _) = a
     recurse a@(Loc  _) = a
     recurse (Seq   xs) = Seq $ map every xs
     recurse (Last  xs) = Last $ map every xs
@@ -308,6 +315,7 @@ everything combine f = recurse
     recurse x@Never    = f x
     recurse x@Wait0    = f x
     recurse x@(Wait _) = f x
+    recurse x@(Uniform _ _) = f x
     recurse x@(Loc  _) = f x
     recurse x@(Seq   xs) =
         foldl' combine (f x) $ map recurse xs

--- a/lib/deltaq/test/DeltaQ/Gen/Term.hs
+++ b/lib/deltaq/test/DeltaQ/Gen/Term.hs
@@ -42,6 +42,13 @@ genWait = do
     NonNegative a <- arbitrary
     pure $ Wait a
 
+-- | Generate a 'uniform'.
+genUniform :: Gen (Term v)
+genUniform = do
+    NonNegative a <- arbitrary
+    NonNegative d <- arbitrary
+    pure $ Uniform a (a + d)
+
 -- | Generate a 'var' with a short name.
 genVar :: Gen v -> Gen (Term v)
 genVar = fmap Var
@@ -53,6 +60,7 @@ genSimpleOutcome genName =
         [ (20, genVar genName)
         , ( 4, genWait)
         , ( 2, pure Wait0)
+        , ( 4, genUniform)
         , ( 4, pure Never)
         , ( 1, pure $ Loc "test")
         ]


### PR DESCRIPTION
This pull requests adds a constructor `Uniform` to `Term` and also implements basic rendering in an outcome diagram.