### PR TITLE
Relax dependency on diagrams-lib to 1.6 and add GHC version 9.12.2

### DIFF
--- a/lib/deltaq/deltaq.cabal
+++ b/lib/deltaq/deltaq.cabal
@@ -38,7 +38,7 @@ extra-doc-files:
   README.md
   images/hops.svg
 
-tested-with:     GHC ==8.10.7 || ==9.6.7 || ==9.10.3
+tested-with:     GHC ==8.10.7 || ==9.6.7 || ==9.10.3 || ==9.12.2
 
 common warnings
   ghc-options: -Wall
@@ -59,7 +59,7 @@ library
     , lattices                >=2.2      && <2.3
     , probability-polynomial  >=1.0.1    && <1.1
     , diagrams-lib            >=1.4.5    && <1.6
-    , diagrams-svg            >=1.5      && <1.6
+    , diagrams-svg            >=1.5      && <1.7
 
   exposed-modules:
     DeltaQ

--- a/lib/deltaq/deltaq.cabal
+++ b/lib/deltaq/deltaq.cabal
@@ -58,8 +58,8 @@ library
     , deepseq                 >=1.4.4.0  && <1.6
     , lattices                >=2.2      && <2.3
     , probability-polynomial  >=1.0.1    && <1.1
-    , diagrams-lib            >=1.4.5    && <1.6
-    , diagrams-svg            >=1.5      && <1.7
+    , diagrams-lib            >=1.4.5    && <1.7
+    , diagrams-svg            >=1.5      && <1.6
 
   exposed-modules:
     DeltaQ


### PR DESCRIPTION
Following the release of diagrams-lib 1.6, relaxed bounds for that package (and tested with GHC 9.12.2)